### PR TITLE
建築可能なNestElementとしてNestBuildableElementを定義

### DIFF
--- a/Assets/AntDiary/Prefabs/Ants/Debug/DebugAnt.prefab
+++ b/Assets/AntDiary/Prefabs/Ants/Debug/DebugAnt.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5942265581793713461}
   - component: {fileID: 1379007370299781532}
+  - component: {fileID: -1145871431695893846}
   m_Layer: 0
   m_Name: DebugAnt
   m_TagString: Untagged
@@ -43,3 +44,53 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: adc1650d382824740a3e8aef598e6d29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!212 &-1145871431695893846
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3766229703136058862}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.16, y: 0.16}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/AntDiary/Scripts/Ants/Debug/DebugAnt.cs
+++ b/Assets/AntDiary/Scripts/Ants/Debug/DebugAnt.cs
@@ -1,6 +1,10 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using UniRx;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace AntDiary
 {
@@ -13,9 +17,33 @@ namespace AntDiary
         }
 
         // Update is called once per frame
-        void Update()
+        protected override float MovementSpeed { get; } = 1f;
+
+        private bool pathWayStarted = false;
+
+        protected override void Update()
         {
-            
+            base.Update();
+
+            if (!pathWayStarted)
+            {
+                if (SetRandomDestination()) pathWayStarted = true;
+            }
+        }
+
+        private bool SetRandomDestination()
+        {
+            var allNodes = NestSystem.Instance.NestPathNodes;
+            if (allNodes.Any())
+            {
+                var dst = allNodes.ElementAt(Random.Range(0, allNodes.Count()));
+                StartForPathNode(dst, () => SetRandomDestination(), () => Debug.Log("Aborted"));
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }

--- a/Assets/AntDiary/Scripts/Roads/Debug/DebugRoad.cs
+++ b/Assets/AntDiary/Scripts/Roads/Debug/DebugRoad.cs
@@ -32,8 +32,8 @@ namespace AntDiary
             var position = transform.position;
             nodes = new[]
             {
-                new NestPathRoadNode(this, SelfData.From - (Vector2) position, "wild"),
-                new NestPathRoadNode(this, SelfData.To - (Vector2) position, "wild")
+                new NestPathRoadNode(this, SelfData.From - (Vector2) position, "wild_a"),
+                new NestPathRoadNode(this, SelfData.To - (Vector2) position, "wild_b")
             };
 
             edges = new[]

--- a/Assets/AntDiary/Scripts/Roads/Debug/DebugRoad.cs
+++ b/Assets/AntDiary/Scripts/Roads/Debug/DebugRoad.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace AntDiary
 {
-    public class DebugRoad : NestElement<DebugRoadData>
+    public class DebugRoad : Road<DebugRoadData>
     {
         [SerializeField] private Collider2D blockingShape;
         
@@ -32,8 +32,8 @@ namespace AntDiary
             var position = transform.position;
             nodes = new[]
             {
-                new NestPathRoadNode(this, SelfData.From - (Vector2) position, "from"),
-                new NestPathRoadNode(this, SelfData.To - (Vector2) position, "to")
+                new NestPathRoadNode(this, SelfData.From - (Vector2) position, "wild"),
+                new NestPathRoadNode(this, SelfData.To - (Vector2) position, "wild")
             };
 
             edges = new[]
@@ -41,5 +41,7 @@ namespace AntDiary
                 new NestPathLocalEdge(nodes[0], nodes[1])
             };
         }
+
+        public override float RequiredResources { get; }
     }
 }

--- a/Assets/AntDiary/Scripts/Roads/Debug/DebugRoadData.cs
+++ b/Assets/AntDiary/Scripts/Roads/Debug/DebugRoadData.cs
@@ -6,9 +6,10 @@ using UnityEngine;
 namespace AntDiary
 {
     [MessagePackObject()]
-    public class DebugRoadData : NestElementData
+    public class DebugRoadData : RoadData
     {
-        [Key(10)] public Vector2 From { get; set; }
-        [Key(11)] public Vector2 To { get; set; }
+        //Keyは30~
+        [Key(30)] public Vector2 From { get; set; }
+        [Key(31)] public Vector2 To { get; set; }
     }
 }

--- a/Assets/AntDiary/Scripts/Rooms/Debug/DebugRoom.cs
+++ b/Assets/AntDiary/Scripts/Rooms/Debug/DebugRoom.cs
@@ -36,7 +36,7 @@ namespace AntDiary
             Vector2 y = new Vector2(0, boundingRect.height * 0.5f);
             nodes = new[]
             {
-                //new NestPathRoomNode(this, center),
+                new NestPathRoomNode(this, center),
                 new NestPathRoomNode(this, center + x, "right"),
                 new NestPathRoomNode(this, center + y, "top"),
                 new NestPathRoomNode(this, center - x, "left"),
@@ -45,15 +45,18 @@ namespace AntDiary
 
             edges = new[]
             {
-                /*new NestPathLocalEdge(nodes[0], nodes[1]),
+                new NestPathLocalEdge(nodes[0], nodes[1]),
                 new NestPathLocalEdge(nodes[0], nodes[2]),
                 new NestPathLocalEdge(nodes[0], nodes[3]),
-                new NestPathLocalEdge(nodes[0], nodes[4]),*/
+                new NestPathLocalEdge(nodes[0], nodes[4]),
+                
                 new NestPathLocalEdge(nodes[1], nodes[2]),
                 new NestPathLocalEdge(nodes[2], nodes[3]),
-                new NestPathLocalEdge(nodes[3], nodes[0]),
-                new NestPathLocalEdge(nodes[0], nodes[1]),
+                new NestPathLocalEdge(nodes[3], nodes[4]),
+                new NestPathLocalEdge(nodes[4], nodes[1]),
             };
         }
+
+        public override float RequiredResources { get; }
     }
 }

--- a/Assets/AntDiary/Scripts/Rooms/Debug/DebugRoomData.cs
+++ b/Assets/AntDiary/Scripts/Rooms/Debug/DebugRoomData.cs
@@ -8,6 +8,6 @@ namespace AntDiary
     [MessagePackObject()]
     public class DebugRoomData : RoomData
     {
-        
+        //Keyは30~
     }
 }

--- a/Assets/AntDiary/Scripts/System/AStarSearcher.cs
+++ b/Assets/AntDiary/Scripts/System/AStarSearcher.cs
@@ -77,7 +77,10 @@ namespace AntDiary{
 				AStarNode aStarNode = openNodes[0];
 
 				var connectedNodes = aStarNode.Node.GetConnectedNodes();
-				foreach(var edge in aStarNode.Node.Edges){
+				foreach(var edge in aStarNode.Node.Edges)
+				{
+					//通貨不能エッジはスキップ
+					if (!edge.CanGetThrough) continue;
 					var cost = aStarNode.Cost + edge.Cost;
 					
 					var other = edge.GetOtherNode(aStarNode.Node);

--- a/Assets/AntDiary/Scripts/System/Ant.cs
+++ b/Assets/AntDiary/Scripts/System/Ant.cs
@@ -1,14 +1,146 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using UniRx;
 using UnityEngine;
 
 namespace AntDiary
 {
-
     public abstract class Ant : MonoBehaviour
     {
         public abstract AntData Data { get; }
+
+        protected abstract float MovementSpeed { get; }
+
+        protected virtual void Update()
+        {
+            UpdateMovementOnPath();
+        }
+
+        private void UpdateMovementOnPath()
+        {
+            if (NextNode != null)
+            {
+                var d = NextNode.WorldPosition - (Vector2) transform.position;
+                float step = MovementSpeed * Time.deltaTime;
+                if (d.sqrMagnitude <= step * step)
+                {
+                    transform.position = NextNode.WorldPosition;
+                    CurrentNode = NextNode;
+                    NextNode = null;
+                    if (CurrentNode == CurrentTargetNode)
+                    {
+                        //到着
+                        var a = OnArrived;
+                        OnArrived = null;
+                        OnAborted = null;
+                        a?.Invoke();
+                    }
+                    else
+                    {
+                        UpdatePath();
+                    }
+                }
+                else
+                {
+                    transform.position = (Vector2) transform.position + d.normalized * step;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 現在の目的地。
+        /// </summary>
+        protected NestPathNode CurrentTargetNode { get; private set; }
+
+        /// <summary>
+        /// 現在の経路で、次に通過する予定のノード。
+        /// </summary>
+        protected NestPathNode NextNode { get; private set; }
+
+        /// <summary>
+        /// 現在位置している、または最後に位置したノード。
+        /// </summary>
+        protected NestPathNode CurrentNode { get; private set; }
+
+        private Action OnArrived { get; set; }
+        private Action OnAborted { get; set; }
+
+        /// <summary>
+        /// 目的のNodeへの自動移動を開始する。
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="onArrived">ノードへ到着した際のコールバック。</param>
+        /// <param name="onAborted">何らかの理由で移動が中止された際のコールバック。</param>
+        public void StartForPathNode(NestPathNode node, Action onArrived = null, Action onAborted = null)
+        {
+            CancelMovement();
+            
+            OnAborted = onAborted;
+            OnArrived = onArrived;
+
+            CurrentTargetNode = node;
+            UpdatePath();
+        }
+
+        private void UpdatePath()
+        {
+            //現在位置ノードが不明な場合や、既知のCurrentNodeが実際の現在位置から離れすぎている場合は、現在位置ノードを再計算
+            if (CurrentNode == null || (CurrentNode.WorldPosition - (Vector2) transform.position).sqrMagnitude > 1f)
+            {
+                //現在位置が不明なので、検索
+                float minSqrDistance = float.MaxValue;
+                NestPathNode argMinSqrDistance = null;
+                foreach (var node in NestSystem.Instance.NestPathNodes)
+                {
+                    float distance = (node.WorldPosition - (Vector2) transform.position).sqrMagnitude;
+                    if (distance < minSqrDistance)
+                    {
+                        minSqrDistance = distance;
+                        argMinSqrDistance = node;
+                    }
+                }
+
+                //とりあえず一番近いノードに移動
+                NextNode = argMinSqrDistance ?? throw new NullReferenceException("巣にIPathNodeが見つかりませんでした。");
+            }
+            else
+            {
+                if (CurrentTargetNode == null) throw new NullReferenceException("ターゲットのノードを指定してください。");
+                var route = NestSystem.Instance.FindRoute(CurrentNode, CurrentTargetNode);
+                if (route.Count() < 2)
+                {
+                    //ルート計算に失敗。接続されていない？
+                    CurrentTargetNode = null;
+                    var a = OnAborted;
+                    OnArrived = null;
+                    OnAborted = null;
+                    a?.Invoke();
+                    return;
+                }
+
+                if (route.ElementAt(1) is NestPathNode n)
+                {
+                    NextNode = n;
+                }
+                else throw new InvalidOperationException("ノードはNestPathNodeではない。");
+            }
+        }
+
+        public void CancelMovement()
+        {
+            CurrentTargetNode = null;
+            NextNode = null;
+            CurrentNode = null;
+            
+            var a = OnAborted;
+            OnArrived = null;
+            OnAborted = null;
+            a?.Invoke();
+        }
     }
+
     /// <summary>
     /// シーン上に配置されるアリにとりつけるComponent
     /// </summary>
@@ -18,13 +150,14 @@ namespace AntDiary
         /// 外部公開用のプロパティ
         /// </summary>
         public override AntData Data => SelfData;
-        
+
         /// <summary>
         /// クラス内から参照する用のプロパティ。Dataとインスタンスは同一
         /// </summary>
         protected T SelfData { get; private set; }
+
         protected bool IsInitialized { get; private set; } = false;
-        
+
         /// <summary>
         /// NestSystemがデータを注入するのに使用します。そのほかからは呼ばないでください。
         /// </summary>
@@ -34,6 +167,14 @@ namespace AntDiary
             if (IsInitialized) return;
             SelfData = antData;
             IsInitialized = true;
+            
+            //位置データをセーブデータと同期
+            SaveUnit.Current.OnBeforeSave.Subscribe(_ => Data.Position = transform.position);
+            SaveUnit.OnCurrentSaveUnitChanged.Subscribe(_ =>
+            {
+                SaveUnit.Current.OnBeforeSave.Subscribe(__ => Data.Position = transform.position);
+            });
+            
             OnInitialized();
         }
 

--- a/Assets/AntDiary/Scripts/System/Data/NestBuildableElementData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestBuildableElementData.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    public class NestBuildableElementData : NestElementData
+    {
+        //Keyは10~19
+        [Key(10)] public bool IsUnderConstruction { get; set; } = false;
+        
+        /// <summary>
+        /// 建築の進捗
+        /// </summary>
+        [Key(11)] public float BuildingProgress { get; set; } = 0;
+    }
+}

--- a/Assets/AntDiary/Scripts/System/Data/NestBuildableElementData.cs.meta
+++ b/Assets/AntDiary/Scripts/System/Data/NestBuildableElementData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 541442379e364c74ea5bb03e87de5f1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
@@ -9,6 +9,7 @@ namespace AntDiary
     [Union(1, typeof(DebugRoadData))]
     public abstract class NestElementData
     {
+        //Keyは0~9を使用することにします。足りなくなったらまた考えるので@rucchoまで。
         [Key(0)] public string Guid { get; set; } = System.Guid.NewGuid().ToString();
         [Key(1)] public Vector2 Position { get; set; }
     }

--- a/Assets/AntDiary/Scripts/System/Data/RoadData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/RoadData.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 
 namespace AntDiary
 {
-    public abstract class Room<T> : NestBuildableElement<T> where T : RoomData
+    public abstract class RoadData : NestBuildableElementData
     {
-        
+        //Keyは20~29
     }
 }

--- a/Assets/AntDiary/Scripts/System/Data/RoadData.cs.meta
+++ b/Assets/AntDiary/Scripts/System/Data/RoadData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aaf5df374aff52247b55083e80d589df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/Data/RoomData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/RoomData.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 
 namespace AntDiary
 {
-    public abstract class RoomData : NestElementData
+    public abstract class RoomData : NestBuildableElementData
     {
-        
+        //Keyは20~29
     }
 }

--- a/Assets/AntDiary/Scripts/System/IPathEdge.cs
+++ b/Assets/AntDiary/Scripts/System/IPathEdge.cs
@@ -12,5 +12,10 @@ namespace AntDiary
         IPathNode A { get; }
         IPathNode B { get; }
         float Cost { get; }
+        
+        /// <summary>
+        /// 通行の可否。
+        /// </summary>
+        bool CanGetThrough { get; }
     }
 }

--- a/Assets/AntDiary/Scripts/System/NestBuildableElement.cs
+++ b/Assets/AntDiary/Scripts/System/NestBuildableElement.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AntDiary
+{
+    public abstract class NestBuildableElement<T> : NestElement<T> where T : NestBuildableElementData
+    {
+        /// <summary>
+        /// 建築の完了に必要な労働コスト
+        /// </summary>
+        public abstract float RequiredResources { get; }
+        public bool IsUnderConstruction
+        {
+            get => SelfData.IsUnderConstruction;
+        }
+
+        /// <summary>
+        /// 建築のために労働コストを投入する。
+        /// </summary>
+        public void Commit(float buildingResource)
+        {
+            if (!IsUnderConstruction) return;
+
+            SelfData.BuildingProgress += buildingResource;
+            if (SelfData.BuildingProgress >= RequiredResources)
+            {
+                SelfData.IsUnderConstruction = false;
+                SelfData.BuildingProgress = 0;
+                OnBuildingCompleted();
+            }
+        }
+        
+        /// <summary>
+        /// 建築が完了したときに呼ばれる。
+        /// </summary>
+        protected virtual void OnBuildingCompleted()
+        {}
+        
+    }
+}

--- a/Assets/AntDiary/Scripts/System/NestBuildableElement.cs.meta
+++ b/Assets/AntDiary/Scripts/System/NestBuildableElement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cf5edce43c295b4d8704814c7408d2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/NestPathEdge.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathEdge.cs
@@ -9,6 +9,7 @@ public abstract class NestPathEdge : IPathEdge
     IPathNode IPathEdge.B => B;
 
     public float Cost => (A.WorldPosition - B.WorldPosition).magnitude;
+    public abstract bool CanGetThrough { get; }
 
     IPathNode IPathEdge.A => A;
 

--- a/Assets/AntDiary/Scripts/System/NestPathElementEdge.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathElementEdge.cs
@@ -9,6 +9,32 @@ namespace AntDiary
     public class NestPathElementEdge : NestPathEdge
     {
         public NestPathElementEdgeData Data { get; }
+
+        //建築中のノードとつながっているときは通過できない
+        public override bool CanGetThrough
+        {
+            get
+            {
+                if (A.Host.Data is NestBuildableElementData dataA)
+                {
+                    if (dataA.IsUnderConstruction)
+                    {
+                        return false;
+                    }
+                }
+                
+                if (B.Host.Data is NestBuildableElementData dataB)
+                {
+                    if (dataB.IsUnderConstruction)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+        
         public override NestPathNode A { get; }
         public override NestPathNode B { get; }
 

--- a/Assets/AntDiary/Scripts/System/NestPathLocalEdge.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathLocalEdge.cs
@@ -5,8 +5,12 @@ using UnityEngine;
 
 namespace AntDiary
 {
+    /// <summary>
+    /// NestElement内部の経路ノード同士の接続を示す。
+    /// </summary>
     public class NestPathLocalEdge : NestPathEdge
     {
+        public override bool CanGetThrough => true;
         public override NestPathNode A { get; }
         public override NestPathNode B { get; }
         

--- a/Assets/AntDiary/Scripts/System/NestPathRoadNode.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathRoadNode.cs
@@ -17,7 +17,7 @@ namespace AntDiary
         {
             if (other is NestPathRoadNode || other is NestPathRoomNode)
             {
-                if (this.Name == "wild" || other.Name == "wild") return true;
+                if (this.Name.StartsWith("wild") || other.Name.StartsWith("wild")) return true;
                 switch (other.Name)
                 {
                     case "right":

--- a/Assets/AntDiary/Scripts/System/NestPathRoadNode.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathRoadNode.cs
@@ -15,6 +15,23 @@ namespace AntDiary
         
         public override bool IsConnectable(NestPathNode other)
         {
+            if (other is NestPathRoadNode || other is NestPathRoomNode)
+            {
+                if (this.Name == "wild" || other.Name == "wild") return true;
+                switch (other.Name)
+                {
+                    case "right":
+                        return this.Name == "left";
+                    case "top":
+                        return this.Name == "bottom";
+                    case "left":
+                        return this.Name == "right";
+                    case "bottom":
+                        return this.Name == "top";
+                    default:
+                        return true;
+                }
+            }
             return true;
         }
     }

--- a/Assets/AntDiary/Scripts/System/NestPathRoomNode.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathRoomNode.cs
@@ -18,7 +18,7 @@ namespace AntDiary
             //道のノードとだけ接続可能
             if (other is NestPathRoadNode)
             {
-                if (this.Name == "wild" || other.Name == "wild") return true;
+                if (this.Name.StartsWith("wild") || other.Name.StartsWith("wild")) return true;
                 
                 switch (other.Name)
                 {

--- a/Assets/AntDiary/Scripts/System/NestPathRoomNode.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathRoomNode.cs
@@ -18,6 +18,8 @@ namespace AntDiary
             //道のノードとだけ接続可能
             if (other is NestPathRoadNode)
             {
+                if (this.Name == "wild" || other.Name == "wild") return true;
+                
                 switch (other.Name)
                 {
                     case "right":

--- a/Assets/AntDiary/Scripts/System/NestSystem.cs
+++ b/Assets/AntDiary/Scripts/System/NestSystem.cs
@@ -55,13 +55,31 @@ namespace AntDiary
         public BuildingSystem BuildingSystem { get; set; }
 
         private readonly List<Ant> spawnedAnts = new List<Ant>();
+        
+        /// <summary>
+        /// 巣に存在するすべてのアリを取得する。
+        /// </summary>
         public IReadOnlyList<Ant> SpawnedAnt => spawnedAnts;
 
         private readonly List<NestElement> nestElements = new List<NestElement>();
+        
+        /// <summary>
+        /// 巣に存在するすべてのNestElementを取得する。
+        /// </summary>
         public IReadOnlyList<NestElement> NestElements => nestElements;
 
         private readonly List<NestPathElementEdge> elementEdges = new List<NestPathElementEdge>();
+        
+        /// <summary>
+        /// NestElement間の接続をすべて取得する。
+        /// </summary>
         public IReadOnlyList<NestPathElementEdge> ElementEdges => elementEdges;
+
+        /// <summary>
+        /// 建築中のNestElementをすべて取得する。
+        /// </summary>
+        public IEnumerable<NestElement> BuildingElements =>
+            nestElements.Where(e => (e.Data is NestBuildableElementData d) && d.IsUnderConstruction);
 
         private void Start()
         {
@@ -279,7 +297,7 @@ namespace AntDiary
                         float posx = x * 4f - 1.5f * 4f;
                         float posy = y * 3f - 1f * 3f;
                         InstantiateNestElement(new DebugRoomData()
-                            {Position = new Vector2(posx, posy)});
+                            {Position = new Vector2(posx, posy), IsUnderConstruction = false});
                     }
 
                     for (int y = 0; y < 3; y++)
@@ -290,7 +308,7 @@ namespace AntDiary
                         var n2 = NestElements[i + 1].GetNodes().First(n => n.Name == "left");
 
                         var road = InstantiateNestElement(new DebugRoadData()
-                            {From = n1.WorldPosition, To = n2.WorldPosition});
+                            {From = n1.WorldPosition, To = n2.WorldPosition, IsUnderConstruction = false});
                         var roadNodes = road.GetNodes();
                         var r1 = roadNodes.ElementAt(0);
                         var r2 = roadNodes.ElementAt(1);
@@ -308,7 +326,7 @@ namespace AntDiary
                         var n2 = NestElements[i + 4].GetNodes().First(n => n.Name == "bottom");
 
                         var road = InstantiateNestElement(new DebugRoadData()
-                            {From = n1.WorldPosition, To = n2.WorldPosition});
+                            {From = n1.WorldPosition, To = n2.WorldPosition, IsUnderConstruction = false});
                         var roadNodes = road.GetNodes();
                         var r1 = roadNodes.ElementAt(0);
                         var r2 = roadNodes.ElementAt(1);

--- a/Assets/AntDiary/Scripts/System/NestSystem.cs
+++ b/Assets/AntDiary/Scripts/System/NestSystem.cs
@@ -81,6 +81,11 @@ namespace AntDiary
         public IEnumerable<NestElement> BuildingElements =>
             nestElements.Where(e => (e.Data is NestBuildableElementData d) && d.IsUnderConstruction);
 
+        /// <summary>
+        /// 巣に存在するすべてのIPathNodeを取得する。
+        /// </summary>
+        public IEnumerable<NestPathNode> NestPathNodes => NestElements.SelectMany(e => e.GetNodes());
+
         private void Start()
         {
             if (SaveUnit.Current != null)

--- a/Assets/AntDiary/Scripts/System/Node.cs
+++ b/Assets/AntDiary/Scripts/System/Node.cs
@@ -74,5 +74,6 @@ namespace AntDiary{
         public IPathNode A { get; }
         public IPathNode B { get; }
         public float Cost { get; }
+        public bool CanGetThrough => true;
     }
 }

--- a/Assets/AntDiary/Scripts/System/PathNodeExtensions.cs
+++ b/Assets/AntDiary/Scripts/System/PathNodeExtensions.cs
@@ -10,7 +10,7 @@ namespace AntDiary
     {
         public static IEnumerable<IPathNode> GetConnectedNodes(this IPathNode target)
         {
-            return target.Edges.Select(e => e.GetOtherNode(target));
+            return target.Edges.Where(e => e.CanGetThrough).Select(e => e.GetOtherNode(target));
         }
 
         public static IPathNode GetOtherNode(this IPathEdge target, IPathNode one)

--- a/Assets/AntDiary/Scripts/System/Road.cs
+++ b/Assets/AntDiary/Scripts/System/Road.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace AntDiary
 {
-    public abstract class Room<T> : NestBuildableElement<T> where T : RoomData
+    public abstract class Road<T> : NestBuildableElement<T> where T : RoadData
     {
         
     }

--- a/Assets/AntDiary/Scripts/System/Road.cs.meta
+++ b/Assets/AntDiary/Scripts/System/Road.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c0eed9365994784f953bba9e79abcbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
建築システム関連の追加・変更をいくつか

- NestBuildableElement, NestBuildableElementData
  - 建築リソースの投入APIと、建築完了コールバックを用意したので、建築コスト管理がだいぶ楽にできます
    - API
      - void Commit(float buildingResource) : 建築リソースの投入
      - bool IsUnderConstruction : 建築中かどうか
    - 継承用
      - float RequiredResources : 建築完了に必要なリソース量を返す
      - void OnBuildingCompleted() : 継承すると建築完了時に呼ばれる
  - 生成時に建築完了状態であってほしいときは、生成に使用するNestBuildableElementDataのIsUnderConstructionをfalseにすればOKです（OnBuildingCompletedは呼ばれないので、それは継承先のOnInitialized()とかのタイミングで適切に処理してください）
  - Room, RoadはNestBuildableElementから継承するように変更。部屋や道を作るときはこいつらとRoomData, RoadDataを継承して定義すること 
- NestSystem.BuildingElementsで建築中のNestElementが全部とれます
- IPathEdgeの通行可否の設定とAStarSearcherの対応
  - 建築中のNestBuildableElementの接続は自動的に通行不能になります

#### 追記
アリの経路移動を自動化・共通化([df9ccbb](https://github.com/Original-Intern-Progect/AntDiary/pull/31/commits/df9ccbbe24a2986e14c5f508cbcd4a4bcd0506f0))を追加しました。
Antを継承したスクリプトでStartForPathNode(NestPathNode node)を呼ぶと経路探索から移動まで全自動でやってくれます。