### PR TITLE
建築システム関連の微修正

### DIFF
--- a/Assets/AntDiary/Scripts/System/NestBuildableElement.cs
+++ b/Assets/AntDiary/Scripts/System/NestBuildableElement.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace AntDiary
@@ -10,6 +11,7 @@ namespace AntDiary
         /// 建築の完了に必要な労働コスト
         /// </summary>
         public abstract float RequiredResources { get; }
+
         public bool IsUnderConstruction
         {
             get => SelfData.IsUnderConstruction;
@@ -30,12 +32,21 @@ namespace AntDiary
                 OnBuildingCompleted();
             }
         }
-        
+
         /// <summary>
         /// 建築が完了したときに呼ばれる。
         /// </summary>
         protected virtual void OnBuildingCompleted()
-        {}
-        
+        {
+        }
+
+        /// <summary>
+        /// このNestBuildableElementを建築する際に建築アリが行くべきノードを示す。
+        /// </summary>
+        /// <returns></returns>
+        public virtual IEnumerable<IPathNode> GetBuildingNode()
+        {
+            return GetNodes().Where(n => n.IsExposed).SelectMany(n => n.GetConnectedNodesForeign(true));
+        }
     }
 }

--- a/Assets/AntDiary/Scripts/System/NestSystem.cs
+++ b/Assets/AntDiary/Scripts/System/NestSystem.cs
@@ -193,9 +193,24 @@ namespace AntDiary
         /// <returns>生成されたGameObjectのもつNestElementコンポーネント。</returns>
         public NestElement InstantiateNestElement(NestElementData elementData, bool registerToGameContext = true)
         {
-            Debug.Log(elementData.GetType());
-            var nestElement = nestElementFactories.FirstOrDefault(f => f.DataType == elementData.GetType())
-                ?.InstantiateNestElement(elementData);
+
+            NestElementFactory matchedFactory = null;
+            foreach (var f in nestElementFactories)
+            {
+                if (f.DataType == elementData.GetType())
+                {
+                    matchedFactory = f;
+                    break;
+                }else if (matchedFactory == null && elementData.GetType().IsSubclassOf(f.DataType))
+                {
+                    matchedFactory = f;
+                }
+            }
+            
+            if(!matchedFactory) Debug.LogWarning($"NestSystem: {elementData.GetType()} 用のNestElementFactoryは登録されていません。");
+            
+            var nestElement = matchedFactory?.InstantiateNestElement(elementData);
+            
             if (nestElement != null)
             {
                 if (registerToGameContext)

--- a/Assets/AntDiary/Scripts/System/PathNodeExtensions.cs
+++ b/Assets/AntDiary/Scripts/System/PathNodeExtensions.cs
@@ -8,9 +8,29 @@ namespace AntDiary
 {
     public static class PathNodeExtensions
     {
-        public static IEnumerable<IPathNode> GetConnectedNodes(this IPathNode target)
+        /// <summary>
+        /// このIPathNodeに接続されているIPathNodeをすべて取得する。
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="includeSuspendedEdge">CanGetThroughがfalseなedgeによる接続を含むか。</param>
+        /// <returns></returns>
+        public static IEnumerable<IPathNode>
+            GetConnectedNodes(this IPathNode target, bool includeSuspendedEdge = false)
         {
-            return target.Edges.Where(e => e.CanGetThrough).Select(e => e.GetOtherNode(target));
+            return target.Edges.Where(e => includeSuspendedEdge || e.CanGetThrough).Select(e => e.GetOtherNode(target));
+        }
+
+        /// <summary>
+        /// このIPathNodeに接続されているNestPathNodeのうち、別のNestElementに属しているものをすべて取得する。
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="includeSuspendedEdge">CanGetThroughがfalseなedgeによる接続を含むか。</param>
+        /// <returns></returns>
+        public static IEnumerable<IPathNode> GetConnectedNodesForeign(this NestPathNode target,
+            bool includeSuspendedEdge = false)
+        {
+            return target.Edges.Where(e => includeSuspendedEdge || e.CanGetThrough).OfType<NestPathElementEdge>()
+                .Select(e => e.GetOtherNode(target));
         }
 
         public static IPathNode GetOtherNode(this IPathEdge target, IPathNode one)


### PR DESCRIPTION
NestElementFactory<T>のTが対象NestElementDataの基底クラスでも対応するように変更
NestBuildableElement.GetBuildingNode()で建築アリが行くべきNodeが取得可能に
あと雑多な修正