### PR TITLE
Unity Test Runnerによる自動テストの導入

### DIFF
--- a/.github/workflows/activation.yml
+++ b/.github/workflows/activation.yml
@@ -1,0 +1,19 @@
+name: Acquire Unity activation file
+on: workflow_dispatch
+jobs:
+  activation:
+    name: Request manual activation file 🔑
+    runs-on: ubuntu-latest
+    steps:
+      # Request manual activation file
+      - name: Request manual activation file
+        id: getManualLicenseFile
+        uses: webbertakken/unity-request-manual-activation-file@v1.1
+        with:
+          unityVersion: 2019.4.6f1
+      # Upload artifact (Unity_v20XX.X.XXXX.alf)
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.getManualLicenseFile.outputs.filePath }}
+          path: ${{ steps.getManualLicenseFile.outputs.filePath }}

--- a/.github/workflows/run-unity-testrunner.yml
+++ b/.github/workflows/run-unity-testrunner.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Run Unity Test Runner
+on:
+  pull_request: {}
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
+jobs:
+  test:
+    name: Run Test Runner
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: Library
+          key: Library
+
+      # Test
+      - name: Run tests
+        uses: webbertakken/unity-test-runner@v1.3
+        with:
+          unityVersion: 2019.4.6f1

--- a/Assets/AntDiary.asmdef
+++ b/Assets/AntDiary.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "AntDiary",
+    "references": [
+        "GUID:d8f0fc381555836e38ea7cc25192cacf",
+        "GUID:560b04d1a97f54a4e82edc0cbbb69285"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/AntDiary.asmdef.meta
+++ b/Assets/AntDiary.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0573dab41cbc54442a31b51b80eb0545
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Roads/Debug/DebugRoadFactory.cs
+++ b/Assets/AntDiary/Scripts/Roads/Debug/DebugRoadFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using Unity.Mathematics;
 using UnityEngine;
 
 namespace AntDiary

--- a/Assets/AntDiary/Tests.meta
+++ b/Assets/AntDiary/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c8bb3f02d40cb3409e5a249182516f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Tests/EditMode.meta
+++ b/Assets/AntDiary/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c4f798f2427ec64fbe6cfcbcc14ea04
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Tests/EditMode/EditModeTests.asmdef
+++ b/Assets/AntDiary/Tests/EditMode/EditModeTests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "EditModeTests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/AntDiary/Tests/EditMode/EditModeTests.asmdef.meta
+++ b/Assets/AntDiary/Tests/EditMode/EditModeTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7ac24ed34b0a5a243b2decd43302fb02
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Tests/EditMode/Editor.meta
+++ b/Assets/AntDiary/Tests/EditMode/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc239fe4d6421fa48a5b9356a8340492
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Tests/EditMode/Editor/LayerValidationTest.cs
+++ b/Assets/AntDiary/Tests/EditMode/Editor/LayerValidationTest.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class LayerValidationTest
+    {
+        // A Test behaves as an ordinary method
+        [Test]
+        public void LayerValidationTestSimplePasses()
+        {
+            // Use the Assert class to test conditions
+            Assert.AreNotEqual(-1, LayerMask.NameToLayer("NestElement"));
+
+        }
+
+        // A UnityTest behaves like a coroutine in Play Mode. In Edit Mode you can use
+        // `yield return null;` to skip a frame.
+        [UnityTest]
+        public IEnumerator LayerValidationTestWithEnumeratorPasses()
+        {
+            // Use the Assert class to test conditions.
+            // Use yield to skip a frame.
+            yield return null;
+        }
+    }
+}

--- a/Assets/AntDiary/Tests/EditMode/Editor/LayerValidationTest.cs.meta
+++ b/Assets/AntDiary/Tests/EditMode/Editor/LayerValidationTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da4ef282380f53d4e8191f5a4a5feda4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Tests/PlayMode.meta
+++ b/Assets/AntDiary/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b41ec142b5d7b5a4bbfe17e85ad50e38
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Tests/PlayMode/NestSystemTest.cs
+++ b/Assets/AntDiary/Tests/PlayMode/NestSystemTest.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using AntDiary;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class NestSystemTest
+    {
+        // A Test behaves as an ordinary method
+        [Test]
+        public void NestSystemTestSimplePasses()
+        {
+            // Use the Assert class to test conditions
+            var mainSystemPrefab = AssetDatabase.LoadAssetAtPath<GameObject>("Assets/AntDiary/Prefabs/System/MainSystem.prefab");
+            Assert.NotNull(mainSystemPrefab);
+            var mainSystemGameObject = Object.Instantiate(mainSystemPrefab);
+            var nestSystem = mainSystemGameObject.GetComponentInChildren<NestSystem>();
+            Assert.NotNull(nestSystem);
+
+        }
+    }
+}

--- a/Assets/AntDiary/Tests/PlayMode/NestSystemTest.cs.meta
+++ b/Assets/AntDiary/Tests/PlayMode/NestSystemTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12ad5ed79dc701d4fbbc83bcd1108797
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Tests/PlayMode/PlayModeTests.asmdef
+++ b/Assets/AntDiary/Tests/PlayMode/PlayModeTests.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "PlayModeTests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "AntDiary"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/AntDiary/Tests/PlayMode/PlayModeTests.asmdef.meta
+++ b/Assets/AntDiary/Tests/PlayMode/PlayModeTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1d68480b9a30caf45a5b627a25c8cb16
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
最近、ProjectSettings/TagManager.asset（レイヤーとタグを管理するアセット）が複数人によって度々変更され、コンフリクトが適切に解決されずにPRが通り、追加したはずのレイヤーが消える事態が頻発しています。そもそもグローバルな設定を保持する性質のファイルですので複数人によって変更されるのは当然ですが、レイヤーが消えるとバグるので、どうにかそういったPRが通らないようにしたいという機運が（個人的に）高まっておりました。しかしPRの度に人力でチェックするのはちょっと骨が折れます。
そこで、Unity Test Runnerによるテストを実行できるようにし、エディタ上で予期せぬコード等の変更が無いかをチェックできるようにしてみました。（エディタ上でWindow > General > Test Runnerで起動・実行可能。）今回のレイヤーのチェックに限らず、任意のコードのテストを追加できるようになってます。