### PR TITLE
共通パラメータ実装基盤、建築システム修正、女王アリ部屋

### DIFF
--- a/Assets/AntDiary/Prefabs/Roads/Cross/RoadCross.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/Cross/RoadCross.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 188416874652555640}
   - component: {fileID: 6792360448393821476}
   - component: {fileID: -850332651435124943}
+  - component: {fileID: 5120060624723402404}
+  - component: {fileID: 1980196143701093189}
+  - component: {fileID: 378055079964417642}
   m_Layer: 0
   m_Name: RoadCross
   m_TagString: Untagged
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7eeda5f2af7d4962a992d64d552801cd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: -850332651435124943}
+  constructCost: 15
+  blockingShape: {fileID: 1980196143701093189}
   radius: 2
 --- !u!61 &-850332651435124943
 BoxCollider2D:
@@ -109,7 +113,7 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -121,5 +125,106 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 0.75, y: 2}
+  m_EdgeRadius: 0
+--- !u!50 &5120060624723402404
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3222424812931283782}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &1980196143701093189
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3222424812931283782}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: -850332651435124943}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -20000000
+      - X: 7499707
+        Y: 20000000
+      - X: -7500000
+        Y: 19999707
+      - X: -7499707
+        Y: -20000000
+  - m_Collider: {fileID: 378055079964417642}
+    m_ColliderPaths:
+    - - X: 19999707
+        Y: -7500000
+      - X: 19999707
+        Y: 7500000
+      - X: -20000000
+        Y: 7499707
+      - X: -19999707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.7499414, y: -2}
+      - {x: 0.7500001, y: -0.75}
+      - {x: 1.9999708, y: -0.74997073}
+      - {x: 1.9999415, y: 0.75}
+      - {x: 0.74997073, y: 0.7500202}
+      - {x: 0.7499414, y: 2}
+      - {x: -0.75, y: 1.9999415}
+      - {x: -0.7500202, y: 0.7499799}
+      - {x: -2, y: 0.7499414}
+      - {x: -1.9999415, y: -0.75}
+      - {x: -0.7499799, y: -0.7500294}
+      - {x: -0.7499414, y: -2}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005
+--- !u!61 &378055079964417642
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3222424812931283782}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2, y: 0.75}
   m_EdgeRadius: 0

--- a/Assets/AntDiary/Prefabs/Roads/L/RoadLBottom.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/L/RoadLBottom.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 830382015321722145}
   - component: {fileID: -1639828606792461804}
   - component: {fileID: 4048603914397874522}
+  - component: {fileID: -7941236421163733560}
+  - component: {fileID: -7753093254525183341}
+  - component: {fileID: -4654233011543204884}
   m_Layer: 0
   m_Name: RoadLBottom
   m_TagString: Untagged
@@ -96,7 +99,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   constructCost: 15
-  blockingShape: {fileID: 4048603914397874522}
+  blockingShape: {fileID: -4654233011543204884}
   radius: 2
 --- !u!61 &4048603914397874522
 BoxCollider2D:
@@ -110,8 +113,8 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: -0.3125}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -122,5 +125,100 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 0.75, y: 1.375}
   m_EdgeRadius: 0
+--- !u!61 &-7941236421163733560
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3806581879407198467}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: -0.3125, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.375, y: 0.75}
+  m_EdgeRadius: 0
+--- !u!50 &-7753093254525183341
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3806581879407198467}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &-4654233011543204884
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3806581879407198467}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 4048603914397874522}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -20000000
+      - X: 7499707
+        Y: 7500000
+      - X: -7500000
+        Y: 7499707
+      - X: -7499707
+        Y: -20000000
+  - m_Collider: {fileID: -7941236421163733560}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -7500000
+      - X: 7499707
+        Y: 7500000
+      - X: -20000000
+        Y: 7499707
+      - X: -19999707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.7499414, y: -2}
+      - {x: 0.7499414, y: 0.75}
+      - {x: -2, y: 0.7499414}
+      - {x: -1.9999415, y: -0.75}
+      - {x: -0.749984, y: -0.7500294}
+      - {x: -0.7499414, y: -2}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Roads/L/RoadLLeft.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/L/RoadLLeft.prefab
@@ -12,8 +12,11 @@ GameObject:
   - component: {fileID: 8786949559207090159}
   - component: {fileID: -7844273668637754838}
   - component: {fileID: 4376898755938400209}
+  - component: {fileID: 2758130891950613884}
+  - component: {fileID: 4576607719712834450}
+  - component: {fileID: 3461114759576628322}
   m_Layer: 0
-  m_Name: RoadLBottom
+  m_Name: RoadLLeft
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd34477b341c424c9ed8bdf5e7d44c51, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: 4376898755938400209}
+  constructCost: 15
+  blockingShape: {fileID: 3461114759576628322}
   radius: 2
 --- !u!61 &4376898755938400209
 BoxCollider2D:
@@ -109,8 +113,8 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0.3125}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -121,5 +125,100 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 0.75, y: 1.375}
   m_EdgeRadius: 0
+--- !u!61 &2758130891950613884
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4481878659885024219}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: -0.3125, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.375, y: 0.75}
+  m_EdgeRadius: 0
+--- !u!50 &4576607719712834450
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4481878659885024219}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &3461114759576628322
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4481878659885024219}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 4376898755938400209}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -7500000
+      - X: 7499707
+        Y: 20000000
+      - X: -7500000
+        Y: 19999707
+      - X: -7499707
+        Y: -7500000
+  - m_Collider: {fileID: 2758130891950613884}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -7500000
+      - X: 7499707
+        Y: 7500000
+      - X: -20000000
+        Y: 7499707
+      - X: -19999707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.7499414, y: -0.75}
+      - {x: 0.7499414, y: 2}
+      - {x: -0.75, y: 1.9999415}
+      - {x: -0.7500161, y: 0.749984}
+      - {x: -2, y: 0.7499414}
+      - {x: -1.9999415, y: -0.75}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Roads/L/RoadLRight.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/L/RoadLRight.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 1397420332293885111}
   - component: {fileID: -6929231091793559266}
   - component: {fileID: 8149288018692255819}
+  - component: {fileID: 5313195702261735629}
+  - component: {fileID: 1743815456225671293}
+  - component: {fileID: 4406744833522962293}
   m_Layer: 0
   m_Name: RoadLRight
   m_TagString: Untagged
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd34477b341c424c9ed8bdf5e7d44c51, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: 8149288018692255819}
+  constructCost: 15
+  blockingShape: {fileID: 4406744833522962293}
   radius: 2
 --- !u!61 &8149288018692255819
 BoxCollider2D:
@@ -109,8 +113,8 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: -0.3125}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -121,5 +125,100 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 0.75, y: 1.375}
   m_EdgeRadius: 0
+--- !u!61 &5313195702261735629
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7520055242711420486}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0.3125, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.375, y: 0.75}
+  m_EdgeRadius: 0
+--- !u!50 &1743815456225671293
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7520055242711420486}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &4406744833522962293
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7520055242711420486}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 8149288018692255819}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -20000000
+      - X: 7499707
+        Y: 7500000
+      - X: -7500000
+        Y: 7499707
+      - X: -7499707
+        Y: -20000000
+  - m_Collider: {fileID: 5313195702261735629}
+    m_ColliderPaths:
+    - - X: 19999707
+        Y: -7500000
+      - X: 19999707
+        Y: 7500000
+      - X: -7500000
+        Y: 7499707
+      - X: -7499707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.7499414, y: -2}
+      - {x: 0.7500001, y: -0.75}
+      - {x: 1.9999708, y: -0.74997073}
+      - {x: 1.9999415, y: 0.75}
+      - {x: -0.75, y: 0.7499414}
+      - {x: -0.7499414, y: -2}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Roads/L/RoadLTop.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/L/RoadLTop.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 4732615567309080577}
   - component: {fileID: -6509767419000665875}
   - component: {fileID: 5763930627887399516}
+  - component: {fileID: 7295736262806443523}
+  - component: {fileID: 124821993571150432}
+  - component: {fileID: 187739578407993848}
   m_Layer: 0
   m_Name: RoadLTop
   m_TagString: Untagged
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd34477b341c424c9ed8bdf5e7d44c51, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: 5763930627887399516}
+  constructCost: 15
+  blockingShape: {fileID: 187739578407993848}
   radius: 2
 --- !u!61 &5763930627887399516
 BoxCollider2D:
@@ -109,8 +113,8 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_UsedByComposite: 1
+  m_Offset: {x: 0.3125, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -121,5 +125,100 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 1.375, y: 0.75}
   m_EdgeRadius: 0
+--- !u!61 &7295736262806443523
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8806500201458671346}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0.3125}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.75, y: 1.375}
+  m_EdgeRadius: 0
+--- !u!50 &124821993571150432
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8806500201458671346}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &187739578407993848
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8806500201458671346}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 5763930627887399516}
+    m_ColliderPaths:
+    - - X: 19999707
+        Y: -7500000
+      - X: 19999707
+        Y: 7500000
+      - X: -7500000
+        Y: 7499707
+      - X: -7499707
+        Y: -7500000
+  - m_Collider: {fileID: 7295736262806443523}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -7500000
+      - X: 7499707
+        Y: 20000000
+      - X: -7500000
+        Y: 19999707
+      - X: -7499707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 1.9999415, y: -0.75}
+      - {x: 1.9999415, y: 0.75}
+      - {x: 0.74997073, y: 0.7500161}
+      - {x: 0.7499414, y: 2}
+      - {x: -0.75, y: 1.9999415}
+      - {x: -0.7499414, y: -0.75}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Roads/T/RoadTBottom.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/T/RoadTBottom.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 5991087315756661122}
   - component: {fileID: -4861851039362917176}
   - component: {fileID: -4219261070764297908}
+  - component: {fileID: 5391516012360155183}
+  - component: {fileID: 1694381205637689623}
+  - component: {fileID: 7688867048803302678}
   m_Layer: 0
   m_Name: RoadTBottom
   m_TagString: Untagged
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6bff3b78bff54f828f8ac12489d65c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: -4219261070764297908}
+  constructCost: 15
+  blockingShape: {fileID: 7688867048803302678}
   radius: 2
 --- !u!61 &-4219261070764297908
 BoxCollider2D:
@@ -109,7 +113,7 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -121,5 +125,102 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 2, y: 0.75}
   m_EdgeRadius: 0
+--- !u!61 &5391516012360155183
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6858690017924546155}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: -0.3125}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.75, y: 1.375}
+  m_EdgeRadius: 0
+--- !u!50 &1694381205637689623
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6858690017924546155}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &7688867048803302678
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6858690017924546155}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: -4219261070764297908}
+    m_ColliderPaths:
+    - - X: 19999707
+        Y: -7500000
+      - X: 19999707
+        Y: 7500000
+      - X: -20000000
+        Y: 7499707
+      - X: -19999707
+        Y: -7500000
+  - m_Collider: {fileID: 5391516012360155183}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -20000000
+      - X: 7499707
+        Y: 7500000
+      - X: -7500000
+        Y: 7499707
+      - X: -7499707
+        Y: -20000000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.7499414, y: -2}
+      - {x: 0.7500001, y: -0.75}
+      - {x: 1.9999708, y: -0.74997073}
+      - {x: 1.9999415, y: 0.75}
+      - {x: -2, y: 0.7499414}
+      - {x: -1.9999415, y: -0.75}
+      - {x: -0.749984, y: -0.7500294}
+      - {x: -0.7499414, y: -2}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Roads/T/RoadTLeft.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/T/RoadTLeft.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 5308017991455790466}
   - component: {fileID: -381857277928854085}
   - component: {fileID: -4923023021172504411}
+  - component: {fileID: 317426572991473569}
+  - component: {fileID: 1719277188866088228}
+  - component: {fileID: 4169160098011131312}
   m_Layer: 0
   m_Name: RoadTLeft
   m_TagString: Untagged
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6bff3b78bff54f828f8ac12489d65c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: -4923023021172504411}
+  constructCost: 15
+  blockingShape: {fileID: 4169160098011131312}
   radius: 2
 --- !u!61 &-4923023021172504411
 BoxCollider2D:
@@ -109,7 +113,7 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -121,5 +125,102 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 0.75, y: 2}
   m_EdgeRadius: 0
+--- !u!61 &317426572991473569
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7106690480008643080}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: -0.3125, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.375, y: 0.75}
+  m_EdgeRadius: 0
+--- !u!50 &1719277188866088228
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7106690480008643080}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &4169160098011131312
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7106690480008643080}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: -4923023021172504411}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -20000000
+      - X: 7499707
+        Y: 20000000
+      - X: -7500000
+        Y: 19999707
+      - X: -7499707
+        Y: -20000000
+  - m_Collider: {fileID: 317426572991473569}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -7500000
+      - X: 7499707
+        Y: 7500000
+      - X: -20000000
+        Y: 7499707
+      - X: -19999707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.7499414, y: -2}
+      - {x: 0.7499414, y: 2}
+      - {x: -0.75, y: 1.9999415}
+      - {x: -0.7500202, y: 0.749984}
+      - {x: -2, y: 0.7499414}
+      - {x: -1.9999415, y: -0.75}
+      - {x: -0.7499799, y: -0.7500294}
+      - {x: -0.7499414, y: -2}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Roads/T/RoadTRight.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/T/RoadTRight.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 2146093986554866251}
   - component: {fileID: 4020418549311765662}
   - component: {fileID: -5179580279170297878}
+  - component: {fileID: 8569648908926484744}
+  - component: {fileID: 1748030081781923890}
+  - component: {fileID: 840563335062417242}
   m_Layer: 0
   m_Name: RoadTRight
   m_TagString: Untagged
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6bff3b78bff54f828f8ac12489d65c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: -5179580279170297878}
+  constructCost: 15
+  blockingShape: {fileID: 840563335062417242}
   radius: 2
 --- !u!61 &-5179580279170297878
 BoxCollider2D:
@@ -109,7 +113,7 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -121,5 +125,102 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 0.75, y: 2}
   m_EdgeRadius: 0
+--- !u!61 &8569648908926484744
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4834693826443183656}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0.3125, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.375, y: 0.75}
+  m_EdgeRadius: 0
+--- !u!50 &1748030081781923890
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4834693826443183656}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &840563335062417242
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4834693826443183656}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: -5179580279170297878}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -20000000
+      - X: 7499707
+        Y: 20000000
+      - X: -7500000
+        Y: 19999707
+      - X: -7499707
+        Y: -20000000
+  - m_Collider: {fileID: 8569648908926484744}
+    m_ColliderPaths:
+    - - X: 19999707
+        Y: -7500000
+      - X: 19999707
+        Y: 7500000
+      - X: -7500000
+        Y: 7499707
+      - X: -7499707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 0.7499414, y: -2}
+      - {x: 0.7500001, y: -0.75}
+      - {x: 1.9999708, y: -0.74997073}
+      - {x: 1.9999415, y: 0.75}
+      - {x: 0.74997073, y: 0.7500161}
+      - {x: 0.7499414, y: 2}
+      - {x: -0.75, y: 1.9999415}
+      - {x: -0.7499414, y: -2}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Roads/T/RoadTTop.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/T/RoadTTop.prefab
@@ -12,6 +12,9 @@ GameObject:
   - component: {fileID: 8749932834531559637}
   - component: {fileID: -8804974016577502524}
   - component: {fileID: 4527690795312143063}
+  - component: {fileID: 7639514277530422604}
+  - component: {fileID: 1528878235390998679}
+  - component: {fileID: 6883595821970490620}
   m_Layer: 0
   m_Name: RoadTTop
   m_TagString: Untagged
@@ -95,7 +98,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6bff3b78bff54f828f8ac12489d65c99, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  blockingShape: {fileID: 4527690795312143063}
+  constructCost: 15
+  blockingShape: {fileID: 6883595821970490620}
   radius: 2
 --- !u!61 &4527690795312143063
 BoxCollider2D:
@@ -109,7 +113,7 @@ BoxCollider2D:
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_UsedByComposite: 1
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -121,5 +125,102 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 2, y: 2}
+  m_Size: {x: 2, y: 0.75}
   m_EdgeRadius: 0
+--- !u!61 &7639514277530422604
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234848750310233257}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0.3125}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 2, y: 2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.75, y: 1.375}
+  m_EdgeRadius: 0
+--- !u!50 &1528878235390998679
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234848750310233257}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!66 &6883595821970490620
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4234848750310233257}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 1
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 4527690795312143063}
+    m_ColliderPaths:
+    - - X: 19999707
+        Y: -7500000
+      - X: 19999707
+        Y: 7500000
+      - X: -20000000
+        Y: 7499707
+      - X: -19999707
+        Y: -7500000
+  - m_Collider: {fileID: 7639514277530422604}
+    m_ColliderPaths:
+    - - X: 7499707
+        Y: -7500000
+      - X: 7499707
+        Y: 20000000
+      - X: -7500000
+        Y: 19999707
+      - X: -7499707
+        Y: -7500000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 1.9999415, y: -0.75}
+      - {x: 1.9999415, y: 0.75}
+      - {x: 0.74997073, y: 0.7500202}
+      - {x: 0.7499414, y: 2}
+      - {x: -0.75, y: 1.9999415}
+      - {x: -0.7500161, y: 0.7499799}
+      - {x: -2, y: 0.7499414}
+      - {x: -1.9999415, y: -0.75}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005

--- a/Assets/AntDiary/Prefabs/Rooms/Queen.meta
+++ b/Assets/AntDiary/Prefabs/Rooms/Queen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d8520966ae7dd347a00c71f74707d06
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Prefabs/Rooms/Queen/QueenRoom.prefab
+++ b/Assets/AntDiary/Prefabs/Rooms/Queen/QueenRoom.prefab
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8997941612626448647
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8103977213870865546}
+  - component: {fileID: 6384712236507068878}
+  - component: {fileID: 6506244018250985497}
+  - component: {fileID: 659848008977613094}
+  m_Layer: 0
+  m_Name: QueenRoom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8103977213870865546
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8997941612626448647}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 255.77, y: 452.57, z: -386.12375}
+  m_LocalScale: {x: 2.2, y: 2.2, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6384712236507068878
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8997941612626448647}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300000, guid: 9d1a6780afe3699478f012df40ccbc0b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4, y: 4}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &6506244018250985497
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8997941612626448647}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2193ecc410fbe2946b9d9459a9393b9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  blockingShape: {fileID: 659848008977613094}
+  boundingRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 8
+    height: 4
+--- !u!61 &659848008977613094
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8997941612626448647}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 4, y: 4}
+    newSize: {x: 4, y: 4}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 3.6363637, y: 1.8181819}
+  m_EdgeRadius: 0

--- a/Assets/AntDiary/Prefabs/Rooms/Queen/QueenRoom.prefab.meta
+++ b/Assets/AntDiary/Prefabs/Rooms/Queen/QueenRoom.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f49bae7c2e7cc6742a65fb95d2ba9a1a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Ants/BuilderAnt/BuilderAntCommonData.cs
+++ b/Assets/AntDiary/Scripts/Ants/BuilderAnt/BuilderAntCommonData.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    [MessagePackObject()]
+    public class BuilderAntCommonData : AntCommonData<BuilderAntData>
+    {
+        //Keyは10~
+    }
+}

--- a/Assets/AntDiary/Scripts/Ants/BuilderAnt/BuilderAntCommonData.cs.meta
+++ b/Assets/AntDiary/Scripts/Ants/BuilderAnt/BuilderAntCommonData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0e2b34c26883854eb8df83f6b46d6d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Ants/Debug/DebugAntCommonData.cs
+++ b/Assets/AntDiary/Scripts/Ants/Debug/DebugAntCommonData.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    [MessagePackObject()]
+    public class DebugAntCommonData : AntCommonData<DebugAntData>
+    {
+        //Keyは10~
+    }
+}

--- a/Assets/AntDiary/Scripts/Ants/Debug/DebugAntCommonData.cs.meta
+++ b/Assets/AntDiary/Scripts/Ants/Debug/DebugAntCommonData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 494245c35a24ddf418c8149999bd04e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Ants/Ergate/ErgateAntCommonData.cs
+++ b/Assets/AntDiary/Scripts/Ants/Ergate/ErgateAntCommonData.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    [MessagePackObject()]
+    public class ErgateAntCommonData : AntCommonData<ErgateAntData>
+    {
+        //Keyは10~
+    }
+}

--- a/Assets/AntDiary/Scripts/Ants/Ergate/ErgateAntCommonData.cs.meta
+++ b/Assets/AntDiary/Scripts/Ants/Ergate/ErgateAntCommonData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6eefcfc15bfde5e4ea87d1d84e960645
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Ants/UnemployedAnt/UnemployedAntCommonData.cs
+++ b/Assets/AntDiary/Scripts/Ants/UnemployedAnt/UnemployedAntCommonData.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    [MessagePackObject()]
+    public class UnemployedAntCommonData : AntCommonData<UnemployedAntData>
+    {
+        //Keyは10~
+    }
+}

--- a/Assets/AntDiary/Scripts/Ants/UnemployedAnt/UnemployedAntCommonData.cs.meta
+++ b/Assets/AntDiary/Scripts/Ants/UnemployedAnt/UnemployedAntCommonData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34906d8e3db05cc418fe594aa06ec40d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Roads/Cross/CrossShapeRoad.cs
+++ b/Assets/AntDiary/Scripts/Roads/Cross/CrossShapeRoad.cs
@@ -10,10 +10,10 @@ namespace AntDiary.Scripts.Roads{
 		[SerializeField] private float radius = 2;
 		
 		protected override void OnInitialized(){
-			AddLocalNode("top", "wild_top", Vector2.up * radius);
-			AddLocalNode("right", "wild_right", Vector2.right * radius);
-			AddLocalNode("bottom", "wild_bottom", Vector2.down * radius);
-			AddLocalNode("left", "wild_left", Vector2.left * radius);
+			AddLocalNode("top", "top", Vector2.up * radius);
+			AddLocalNode("right", "right", Vector2.right * radius);
+			AddLocalNode("bottom", "bottom", Vector2.down * radius);
+			AddLocalNode("left", "left", Vector2.left * radius);
 			AddLocalNode("center", "", Vector2.zero * radius);
 			
 			ConnectLocalNodeToIntersection("center", new []{"top", "right", "bottom", "left"});

--- a/Assets/AntDiary/Scripts/Roads/Cross/CrossShapeRoadData.cs
+++ b/Assets/AntDiary/Scripts/Roads/Cross/CrossShapeRoadData.cs
@@ -1,6 +1,10 @@
 
 
+using MessagePack;
+
 namespace AntDiary.Scripts.Roads{
+	
+	[MessagePackObject()]
 	public class CrossShapeRoadData: RoadData{
 		//なし
 	}

--- a/Assets/AntDiary/Scripts/Roads/IShape/IShapeRoad.cs
+++ b/Assets/AntDiary/Scripts/Roads/IShape/IShapeRoad.cs
@@ -14,13 +14,13 @@ namespace AntDiary.Scripts.Roads{
 
 			switch(SelfData.Direction){
 				case EnumRoadHVDirection.Horizontal:
-					AddLocalNode("left", "wild_left", Vector2.left * radius);
-					AddLocalNode("right", "wild_right", Vector2.right * radius);
+					AddLocalNode("left", "left", Vector2.left * radius);
+					AddLocalNode("right", "right", Vector2.right * radius);
 					ConnectLocalNode("left", "right");
 					break;
 				case EnumRoadHVDirection.Vertical:
-					AddLocalNode("top", "wild_top", Vector2.up * radius);
-					AddLocalNode("bottom", "wild_bottom", Vector2.down * radius);
+					AddLocalNode("top", "top", Vector2.up * radius);
+					AddLocalNode("bottom", "bottom", Vector2.down * radius);
 					ConnectLocalNode("top", "bottom");
 					break;
 			}

--- a/Assets/AntDiary/Scripts/Roads/IShape/IShapeRoadData.cs
+++ b/Assets/AntDiary/Scripts/Roads/IShape/IShapeRoadData.cs
@@ -5,7 +5,11 @@ namespace AntDiary.Scripts.Roads{
 	[MessagePackObject()]
 	
 	public class IShapeRoadData: RoadData{
-
+		
+		public IShapeRoadData()
+		{
+		}
+		
 		public IShapeRoadData(EnumRoadHVDirection direction){
 			Direction = direction;
 		}

--- a/Assets/AntDiary/Scripts/Roads/LShape/LShapeRoad.cs
+++ b/Assets/AntDiary/Scripts/Roads/LShape/LShapeRoad.cs
@@ -14,8 +14,8 @@ namespace AntDiary.Scripts.Roads{
 			
 			switch(SelfData.Direction){
 				case EnumRoadDirection.Top:
-					AddLocalNode("top", "wild_top", Vector2.up * radius);
-					AddLocalNode("right", "wild_right", Vector2.right * radius);
+					AddLocalNode("top", "top", Vector2.up * radius);
+					AddLocalNode("right", "right", Vector2.right * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"top", "right"});
 					// _nodes = new[]{
@@ -23,8 +23,8 @@ namespace AntDiary.Scripts.Roads{
 					// };
 					break;
 				case EnumRoadDirection.Right:
-					AddLocalNode("right", "wild_right", Vector2.right * radius);
-					AddLocalNode("bottom", "wild_bottom", Vector2.down * radius);
+					AddLocalNode("right", "right", Vector2.right * radius);
+					AddLocalNode("bottom", "bottom", Vector2.down * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"right", "bottom"});
 					// _nodes = new[]{
@@ -32,8 +32,8 @@ namespace AntDiary.Scripts.Roads{
 					// };
 					break;
 				case EnumRoadDirection.Bottom:
-					AddLocalNode("bottom", "wild_bottom", Vector2.down * radius);
-					AddLocalNode("left", "wild_left", Vector2.left * radius);
+					AddLocalNode("bottom", "bottom", Vector2.down * radius);
+					AddLocalNode("left", "left", Vector2.left * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"bottom", "left"});
 					// _nodes = new[]{
@@ -41,8 +41,8 @@ namespace AntDiary.Scripts.Roads{
 					// };
 					break;
 				case EnumRoadDirection.Left:
-					AddLocalNode("left", "wild_left", Vector2.left * radius);
-					AddLocalNode("top", "wild_top", Vector2.up * radius);
+					AddLocalNode("left", "left", Vector2.left * radius);
+					AddLocalNode("top", "top", Vector2.up * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"left", "top"});
 					// _nodes = new[]{

--- a/Assets/AntDiary/Scripts/Roads/LShape/LShapeRoadData.cs
+++ b/Assets/AntDiary/Scripts/Roads/LShape/LShapeRoadData.cs
@@ -4,6 +4,10 @@ namespace AntDiary.Scripts.Roads{
 	[MessagePackObject()]
 	public class LShapeRoadData: RoadData{
 		
+		public LShapeRoadData()
+		{
+		}
+		
 		public LShapeRoadData(EnumRoadDirection direction){
 			Direction = direction;
 		}

--- a/Assets/AntDiary/Scripts/Roads/TShape/TShapeRoad.cs
+++ b/Assets/AntDiary/Scripts/Roads/TShape/TShapeRoad.cs
@@ -16,9 +16,9 @@ namespace AntDiary.Scripts.Roads{
 			switch(SelfData.Direction){
 				
 				case EnumRoadDirection.Top:
-					AddLocalNode("left", "wild_left", Vector2.left * radius);
-					AddLocalNode("top", "wild_top", Vector2.up * radius);
-					AddLocalNode("right", "wild_right", Vector2.right * radius);
+					AddLocalNode("left", "left", Vector2.left * radius);
+					AddLocalNode("top", "top", Vector2.up * radius);
+					AddLocalNode("right", "right", Vector2.right * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"left", "top", "right"});
 					
@@ -28,9 +28,9 @@ namespace AntDiary.Scripts.Roads{
 					break;
 				
 				case EnumRoadDirection.Right:
-					AddLocalNode("top", "wild_top", Vector2.up * radius);
-					AddLocalNode("right", "wild_right", Vector2.right * radius);
-					AddLocalNode("bottom", "wild_bottom", Vector2.down * radius);
+					AddLocalNode("top", "top", Vector2.up * radius);
+					AddLocalNode("right", "right", Vector2.right * radius);
+					AddLocalNode("bottom", "bottom", Vector2.down * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"top", "right", "bottom"});
 					// 	_nodes = new[]{
@@ -38,9 +38,9 @@ namespace AntDiary.Scripts.Roads{
 					// 	};
 					break;
 				case EnumRoadDirection.Bottom:
-					AddLocalNode("right", "wild_right", Vector2.right * radius);
-					AddLocalNode("bottom", "wild_bottom", Vector2.down * radius);
-					AddLocalNode("left", "wild_left", Vector2.left * radius);
+					AddLocalNode("right", "right", Vector2.right * radius);
+					AddLocalNode("bottom", "bottom", Vector2.down * radius);
+					AddLocalNode("left", "left", Vector2.left * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"right", "bottom", "left"});
 					// 	_nodes = new[]{
@@ -48,9 +48,9 @@ namespace AntDiary.Scripts.Roads{
 					// 	};
 					break;
 				case EnumRoadDirection.Left:
-					AddLocalNode("bottom", "wild_bottom", Vector2.down * radius);
-					AddLocalNode("left", "wild_left", Vector2.left * radius);
-					AddLocalNode("top", "wild_top", Vector2.up * radius);
+					AddLocalNode("bottom", "bottom", Vector2.down * radius);
+					AddLocalNode("left", "left", Vector2.left * radius);
+					AddLocalNode("top", "top", Vector2.up * radius);
 					AddLocalNode("center", "", Vector2.zero * radius);
 					ConnectLocalNodeToIntersection("center", new []{"bottom", "left", "top"});
 					// 	_nodes = new[]{

--- a/Assets/AntDiary/Scripts/Roads/TShape/TShapeRoadData.cs
+++ b/Assets/AntDiary/Scripts/Roads/TShape/TShapeRoadData.cs
@@ -4,6 +4,10 @@ namespace AntDiary.Scripts.Roads{
 	[MessagePackObject()]
 	public class TShapeRoadData: RoadData{
 		
+		public TShapeRoadData()
+		{
+		}
+		
 		public TShapeRoadData(EnumRoadDirection direction){
 			Direction = direction;
 		}

--- a/Assets/AntDiary/Scripts/Rooms/Queen.meta
+++ b/Assets/AntDiary/Scripts/Rooms/Queen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 461d9345932d46047ac39af69310ce06
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoom.cs
+++ b/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoom.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace AntDiary
+{
+    public class QueenRoom : Room<QueenRoomData>
+    {
+        [SerializeField] private Collider2D blockingShape;
+        [SerializeField] private Rect boundingRect = default;
+
+        private NestPathRoomNode[] nodes;
+        private NestPathLocalEdge[] edges;
+        
+        public override Collider2D GetBlockingShape()
+        {
+            return blockingShape;
+        }
+
+        public override bool HasPathNode => true;
+        public override IEnumerable<NestPathNode> GetNodes()
+        {
+            return nodes;
+        }
+
+        public override IEnumerable<NestPathLocalEdge> GetLocalEdges()
+        {
+            return edges;
+        }
+
+        public override float RequiredResources => 0;
+
+        protected override void OnInitialized()
+        {
+            Vector2 center = new Vector2(boundingRect.x, boundingRect.y);
+            Vector2 x = new Vector2(boundingRect.width * 0.5f, 0);
+            Vector2 y = new Vector2(0, boundingRect.height * 0.5f);
+            nodes = new[]
+            {
+                new NestPathRoomNode(this, center),
+                new NestPathRoomNode(this, center + x, "right"),
+                new NestPathRoomNode(this, center + y, "top"),
+                new NestPathRoomNode(this, center - x, "left"),
+                new NestPathRoomNode(this, center - y, "bottom"),
+            };
+
+            edges = new[]
+            {
+                new NestPathLocalEdge(nodes[0], nodes[1]),
+                new NestPathLocalEdge(nodes[0], nodes[2]),
+                new NestPathLocalEdge(nodes[0], nodes[3]),
+                new NestPathLocalEdge(nodes[0], nodes[4]),
+                
+                new NestPathLocalEdge(nodes[1], nodes[2]),
+                new NestPathLocalEdge(nodes[2], nodes[3]),
+                new NestPathLocalEdge(nodes[3], nodes[4]),
+                new NestPathLocalEdge(nodes[4], nodes[1]),
+            };
+        }
+
+        private void OnDrawGizmos()
+        {
+            Vector2 center = new Vector2(boundingRect.x, boundingRect.y);
+            Vector2 x = new Vector2(boundingRect.width * 0.5f, 0);
+            Vector2 y = new Vector2(0, boundingRect.height * 0.5f);
+            Gizmos.DrawWireCube((Vector2)transform.position + center, new Vector3(boundingRect.width, boundingRect.height, 1));
+        }
+        
+    }
+    
+    public static class NestSystemExtensionsQueenRoom
+    {
+        /// <summary>
+        /// 女王部屋を取得します。ない場合はnullが返ります。
+        /// </summary>
+        /// <param name="nestSystem"></param>
+        /// <returns></returns>
+        public static QueenRoom GetQueenRoom(this NestSystem nestSystem)
+        {
+            return nestSystem.NestElements.OfType<QueenRoom>().FirstOrDefault();
+        }
+    }
+}

--- a/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoom.cs.meta
+++ b/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoom.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2193ecc410fbe2946b9d9459a9393b9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomData.cs
+++ b/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomData.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using AntDiary;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    [MessagePackObject()]
+    public class QueenRoomData : RoomData
+    {
+
+    }
+    
+}

--- a/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomData.cs.meta
+++ b/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3936dc8c309ca64c971aa5bed2979a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomFactory.cs
+++ b/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomFactory.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using AntDiary;
+using UnityEngine;
+
+namespace AntDiary
+{
+    public class QueenRoomFactory : NestElementFactory<QueenRoomData>
+    {
+        [SerializeField] private GameObject queenRoomPrefab;
+        public override NestElement InstantiateNestElement(QueenRoomData elementData)
+        {
+            var o = Instantiate(queenRoomPrefab, elementData.Position, Quaternion.identity);
+            var ne = o.GetComponent<QueenRoom>();
+            if(ne == null) throw new NullReferenceException();
+
+            ne.Initialize(elementData);
+            return ne;
+        }
+    }
+}

--- a/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomFactory.cs.meta
+++ b/Assets/AntDiary/Scripts/Rooms/Queen/QueenRoomFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd4d1f5b6c137ec4c944c9da10dd4b83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/Data/AntCommonData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/AntCommonData.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using AntDiary;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    [Union(0, typeof(DebugAntCommonData))]
+    [Union(1, typeof(BuilderAntCommonData))]
+    [Union(2, typeof(ErgateAntCommonData))]
+    [Union(3, typeof(UnemployedAntCommonData))]
+    public abstract class AntCommonDataBase
+    {
+        //派生クラスのメンバのKeyは10~
+
+        [Key(0)] public float MaxHealth { get; set; }
+        [Key(1)] public float BasicMovementSpeed { get; set; }
+        [Key(2)] public float BasicConsumeAmount { get; set; }
+    }
+
+    /// <summary>
+    /// アリの種類に対して共通のパラメータを保持します。
+    /// ゲーム開始時のデフォルト値を設定するにはコンストラクタをオーバーライドして実装してください。
+    /// </summary>
+    public class AntCommonData<T> : AntCommonDataBase where T : AntData
+    {
+        public AntCommonData()
+        {
+            MaxHealth = 1f;
+            BasicMovementSpeed = 1f;
+            BasicConsumeAmount = 1f;
+        }
+    }
+}

--- a/Assets/AntDiary/Scripts/System/Data/AntCommonData.cs.meta
+++ b/Assets/AntDiary/Scripts/System/Data/AntCommonData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3de3a000721901643827e3ad3411a651
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/Data/AntCommonDataRegistryData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/AntCommonDataRegistryData.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    
+    [MessagePackObject]
+    public class AntCommonDataRegistryData
+    {
+        [Key(0)]
+        public List<AntCommonDataBase> CommonData { get; set; } = new List<AntCommonDataBase>()
+        {
+            //初期セーブデータにおけるステータスを定義（各コンストラクタ内で実装）
+            new DebugAntCommonData(),
+            new BuilderAntCommonData(),
+            new ErgateAntCommonData(),
+            new UnemployedAntCommonData()
+        };
+
+        public AntCommonData<T> GetCommonDataFor<T>() where T : AntData
+        {
+            return GetCommonData<AntCommonData<T>>();
+        }
+        
+        public bool TryGetCommonDataFor<T>(out AntCommonData<T> result) where T : AntData
+        {
+            return TryGetCommonData(out result);
+        }
+        
+        public T GetCommonData<T>() where T : AntCommonDataBase
+        {
+            return CommonData.OfType<T>().FirstOrDefault();
+        }
+        
+        public bool TryGetCommonData<T>(out T result) where T : AntCommonDataBase
+        {
+            result = GetCommonData<T>();
+            if (result == default) return false;
+            return true;
+        }
+    }
+}

--- a/Assets/AntDiary/Scripts/System/Data/AntCommonDataRegistryData.cs.meta
+++ b/Assets/AntDiary/Scripts/System/Data/AntCommonDataRegistryData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 835555a698cfca349b4728fa6cbc2be3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/Data/AntData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/AntData.cs
@@ -8,6 +8,7 @@ namespace AntDiary
     [Union(0, typeof(DebugAntData))]
     [Union(2, typeof(ErgateAntData))]
     [Union(1, typeof(UnemployedAntData))]
+    [Union(3, typeof(BuilderAntData))]
     public abstract class AntData
     {
         //方針として、AntDataのメンバ(アリの複数種に共通値)のKeyは0 ~ 99, 各継承クラスのメンバのKeyは100~にしたいな～と
@@ -15,5 +16,9 @@ namespace AntDiary
         [Key(10)] public Vector2 Position { get; set; }
 
         [Key(11)] public bool IsAlive { get; set; } = true;
+        
+        [Key(12)] public float Health { get; set; }
+        
+        
     }
 }

--- a/Assets/AntDiary/Scripts/System/Data/NestBuildableElementData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestBuildableElementData.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace AntDiary
 {
-    public class NestBuildableElementData : NestElementData
+    public abstract class NestBuildableElementData : NestElementData
     {
         //Keyは10~19
         [Key(10)] public bool IsUnderConstruction { get; set; } = false;

--- a/Assets/AntDiary/Scripts/System/Data/NestData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using MessagePack;
 using UnityEngine;
@@ -13,10 +14,14 @@ namespace AntDiary
     {
         [Key(10)]
         public List<AntData> Ants { get; set; } = new List<AntData>();
+        
         [Key(11)]
         public int StoredFood { get; set; }
+        
         [Key(12)]
         public NestStructureData Structure { get; set; } = new NestStructureData();
 
+        [Key(14)]
+        public AntCommonDataRegistryData CommonDataRegistry { get; set; } = new AntCommonDataRegistryData();
     }
 }

--- a/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using AntDiary.Scripts.Roads;
 using MessagePack;
 using UnityEngine;
 
@@ -8,8 +9,16 @@ namespace AntDiary
     [Union(0, typeof(DebugRoomData))]
     [Union(1, typeof(DebugRoadData))]
     [Union(2, typeof(StoreRoomData))]
+    [Union(3, typeof(IShapeRoadData))]
+    [Union(4, typeof(LShapeRoadData))]
+    [Union(5, typeof(CrossShapeRoadData))]
+    [Union(6, typeof(TShapeRoadData))]
     public abstract class NestElementData
     {
+        public NestElementData()
+        {
+        }
+
         //Keyは0~9を使用することにします。足りなくなったらまた考えるので@rucchoまで。
         [Key(0)] public string Guid { get; set; } = System.Guid.NewGuid().ToString();
         [Key(1)] public Vector2 Position { get; set; }

--- a/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
@@ -13,6 +13,8 @@ namespace AntDiary
     [Union(4, typeof(LShapeRoadData))]
     [Union(5, typeof(CrossShapeRoadData))]
     [Union(6, typeof(TShapeRoadData))]
+    [Union(7, typeof(QueenRoomData))]
+    [Union(8, typeof(ChochikukoRoomData))]
     public abstract class NestElementData
     {
         public NestElementData()

--- a/Assets/AntDiary/Scripts/System/NestBuildableElement.cs
+++ b/Assets/AntDiary/Scripts/System/NestBuildableElement.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using UniRx;
 using UnityEngine;
 
 namespace AntDiary
@@ -84,6 +85,14 @@ namespace AntDiary
             SelfData = antData;
             IsInitialized = true;
             gameObject.layer = LayerMask.NameToLayer("NestElement");
+            
+            //位置データをセーブデータと同期
+            SaveUnit.Current.OnBeforeSave.Subscribe(_ => Data.Position = transform.position);
+            SaveUnit.OnCurrentSaveUnitChanged.Subscribe(_ =>
+            {
+                SaveUnit.Current.OnBeforeSave.Subscribe(__ => Data.Position = transform.position);
+            });
+            
             OnInitialized();
         }
 

--- a/Assets/AntDiary/Scripts/System/NestElement.cs
+++ b/Assets/AntDiary/Scripts/System/NestElement.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using UniRx;
 using UnityEngine;
 
 namespace AntDiary
@@ -47,6 +48,14 @@ namespace AntDiary
             SelfData = antData;
             IsInitialized = true;
             gameObject.layer = LayerMask.NameToLayer("NestElement");
+            
+            //位置データをセーブデータと同期
+            SaveUnit.Current.OnBeforeSave.Subscribe(_ => Data.Position = transform.position);
+            SaveUnit.OnCurrentSaveUnitChanged.Subscribe(_ =>
+            {
+                SaveUnit.Current.OnBeforeSave.Subscribe(__ => Data.Position = transform.position);
+            });
+            
             OnInitialized();
         }
 

--- a/Assets/AntDiary/Scripts/System/NestSystem.cs
+++ b/Assets/AntDiary/Scripts/System/NestSystem.cs
@@ -316,6 +316,7 @@ namespace AntDiary
         // private bool showGraph = true;
         private IEnumerable<IPathNode> latestRoute;
         private List<TypeInfo> antDataTypes;
+        private List<TypeInfo> nestElementDataTypes;
         private bool showNestElementData = false;
         private bool showCommonData = false;
 
@@ -421,8 +422,7 @@ namespace AntDiary
 
                 GUILayout.Label("アリのスポーンテスト");
                 if (antDataTypes == null)
-                    antDataTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.DefinedTypes)
-                        .Where(t => t.IsSubclassOf(typeof(AntData))).ToList();
+                    antDataTypes = antFactories.Select(f => f.GetType().BaseType.GenericTypeArguments[0].GetTypeInfo()).ToList();
                 {
                     int i = 0;
                     GUILayout.BeginHorizontal();
@@ -443,6 +443,35 @@ namespace AntDiary
                             if (data != null)
                             {
                                 InstantiateAnt(data);
+                            }
+                        }
+                    }
+
+                    GUILayout.EndHorizontal();
+                }
+                GUILayout.Label("NEstElementのスポーンテスト");
+                if (nestElementDataTypes == null)
+                    nestElementDataTypes = nestElementFactories.Select(f => f.GetType().BaseType.GenericTypeArguments[0].GetTypeInfo()).ToList();
+                {
+                    int i = 0;
+                    GUILayout.BeginHorizontal();
+                    foreach (var nestElementDataType in nestElementDataTypes)
+                    {
+                        if (i % 4 == 0)
+                        {
+                            GUILayout.EndHorizontal();
+                            GUILayout.BeginHorizontal();
+                        }
+
+                        i++;
+
+                        if (GUILayout.Button(nestElementDataType.Name))
+                        {
+                            var constructor = nestElementDataType.GetConstructor(new Type[] { });
+                            var data = (NestElementData) constructor?.Invoke(new object[] { });
+                            if (data != null)
+                            {
+                                InstantiateNestElement(data);
                             }
                         }
                     }

--- a/Assets/AntDiary/Scripts/UI/DragAndDrop_ver2.cs
+++ b/Assets/AntDiary/Scripts/UI/DragAndDrop_ver2.cs
@@ -112,7 +112,7 @@ namespace AntDiary
             }
             else
             {
-                nestelement = NestSystem.Instance.InstantiateNestElement(data);
+                nestelement = NestSystem.Instance.InstantiateNestElement(data, false, false);
                 nestelement.transform.position = screenToWorldPointPosition;
             }
         }
@@ -124,21 +124,29 @@ namespace AntDiary
                 position.z = 10f;
                 screenToWorldPointPosition = Camera.main.ScreenToWorldPoint(position);
                 nestelement.transform.position = screenToWorldPointPosition;
+                
+                //ドラッグ中にスナップ
+                nestelement.transform.position = BuildingSystem.Instance.GetSnappedPosition(nestelement);
 
         }
         public void PushUp()
         {
-
+/*
               if (BuildingSystem.Instance.IsPlaceable(nestelement) == false)//建築可能な領域でない
               {
                 //NestElement削除
-                  NestSystem.Instance.RemoveNestElement(nestelement);
+                  //NestSystem.Instance.RemoveNestElement(nestelement);
                   Destroy(nestelement.gameObject);
               }
               else//建築可能
               {
-                nestelement.transform.position = BuildingSystem.Instance.GetSnappedPosition(nestelement);//付近のノードにスナップした座標へ置く      
+                //nestelement.transform.position = BuildingSystem.Instance.GetSnappedPosition(nestelement);//付近のノードにスナップした座標へ置く      
                 BuildingSystem.Instance.PlaceElementWithAutoConnect(nestelement);//NestSystemへ登録
+              }
+*/
+              if (!BuildingSystem.Instance.PlaceElementWithAutoConnect(nestelement, false))
+              {
+                  Destroy(nestelement.gameObject);
               }
         }
     }

--- a/Assets/AntDiary/Scripts/UI/UIGeneTreeNode.cs
+++ b/Assets/AntDiary/Scripts/UI/UIGeneTreeNode.cs
@@ -20,6 +20,8 @@ namespace AntDiary
             Depth = depth;
             Order = order;
 
+            Label.text = TargetGene.DisplayName;
+
             ParentView.OnSelectedGeneChanged.Subscribe(gene =>
             {
                 bool isSelected = gene == TargetGene;
@@ -71,6 +73,17 @@ namespace AntDiary
             {
                 if (!image) image = GetComponent<Image>();
                 return image;
+            }
+        }
+        
+        private Text label;
+
+        public Text Label
+        {
+            get
+            {
+                if (!label) label = GetComponentInChildren<Text>();
+                return label;
             }
         }
         

--- a/Assets/AntDiary/Scripts/UI/UIGeneTreeNode.cs
+++ b/Assets/AntDiary/Scripts/UI/UIGeneTreeNode.cs
@@ -41,7 +41,7 @@ namespace AntDiary
                     {
                         Image.sprite = selectedSprite;
                     }
-                });
+                }).AddTo(this);
             }
         }
 

--- a/Assets/AntDiary/Tests/EditMode/EditModeTests.asmdef
+++ b/Assets/AntDiary/Tests/EditMode/EditModeTests.asmdef
@@ -2,7 +2,9 @@
     "name": "EditModeTests",
     "references": [
         "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
+        "UnityEditor.TestRunner",
+        "MessagePack",
+        "AntDiary"
     ],
     "includePlatforms": [
         "Editor"
@@ -11,7 +13,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "System.Memory.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Assets/AntDiary/Tests/EditMode/Editor/DataSerializationTest.cs
+++ b/Assets/AntDiary/Tests/EditMode/Editor/DataSerializationTest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using AntDiary;
+using MessagePack;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class DataSerializationTest
+    {
+        // A Test behaves as an ordinary method
+        [Test]
+        public void AntDataSerializationTestSimplePasses()
+        {
+            //AntData継承クラスのうち、非abstractなものを抽出
+            var root = typeof(AntData);
+            var unions = root.GetCustomAttributes(false).OfType<UnionAttribute>();
+            var antDataTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.DefinedTypes)
+                .Where(t => t.IsSubclassOf(root) && !t.IsAbstract);
+            foreach (var t in antDataTypes)
+            {
+                if(!t.GetCustomAttributes(false).Any(a => a is MessagePackObjectAttribute)) Assert.Fail($"MessagePackObjectAttributeを付与していないAntDataがあります: {t.Name}");
+                if (!unions.Any(u => u.SubType == t)) Assert.Fail($"Unionに登録されていないAntDataがあります: {t.Name}");
+            }
+            
+            //シリアライズしてみる
+            
+            foreach (var t in antDataTypes)
+            {
+                var constructor = t.GetConstructor(new Type[0]);
+                Assert.NotNull(constructor, $"引数を持たないコンストラクタが実装されていません: {t.Name}");
+                var data = constructor.Invoke(new object[0]);
+                byte[] bytes = MessagePackSerializer.Serialize(t, data);
+                var deserialized = MessagePackSerializer.Deserialize(t, new ReadOnlyMemory<byte>(bytes));
+                Assert.NotNull(deserialized);
+            }
+            
+        }
+        
+        [Test]
+        public void NestElementDataSerializationTestSimplePasses()
+        {
+            //AntData継承クラスのうち、非abstractなものを抽出
+            var root = typeof(NestElementData);
+            var unions = root.GetCustomAttributes(false).OfType<UnionAttribute>();
+            var nestElementDataTypes = AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.DefinedTypes)
+                .Where(t => t.IsSubclassOf(root) && !t.IsAbstract);
+            foreach (var t in nestElementDataTypes)
+            {
+                if(!t.GetCustomAttributes(false).Any(a => a is MessagePackObjectAttribute)) Assert.Fail($"MessagePackObjectAttributeを付与していないNestElementDataがあります: {t.Name}");
+                if (!unions.Any(u => u.SubType == t)) Assert.Fail($"Unionに登録されていないNestElementDataがあります: {t.Name}");
+            }
+            
+            //シリアライズしてみる
+            
+            foreach (var t in nestElementDataTypes)
+            {
+                var constructor = t.GetConstructor(new Type[0]);
+                Assert.NotNull(constructor, $"引数を持たないコンストラクタが実装されていません: {t.Name}");
+                var data = constructor.Invoke(new object[0]);
+                byte[] bytes = MessagePackSerializer.Serialize(t, data);
+                var deserialized = MessagePackSerializer.Deserialize(t, new ReadOnlyMemory<byte>(bytes));
+                Assert.NotNull(deserialized);
+            }
+        }
+        
+    }
+}

--- a/Assets/AntDiary/Tests/EditMode/Editor/DataSerializationTest.cs.meta
+++ b/Assets/AntDiary/Tests/EditMode/Editor/DataSerializationTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0df23c2c132233245a89a988f241af6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -94,7 +94,7 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.3"
+        "com.unity.test-framework": "1.1.1"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
## AntCommonData
 - アリの種類に対して共通のパラメータを定義・参照可能になった。詳細はScrapbox「NestSystem、アリ・部屋・道のクラス定義などについて」末尾の追記を参照。
## 建築システム修正
 - スナップ動作、多重登録、重複判定等の修正を行った。一通りの建築作業が問題なく行えるようになった
## 女王アリ部屋
 - 部屋の定義とPrefab。スプライトは貯蓄部屋 (空) のものを使用。
 - 女王アリ部屋の取得処理をNestSystem.GetQueenRoom()として定義。
## その他
 - シリアライズ用の記述 (MessagePackObject, Union) の書き忘れをチェックできるEditor Testを追加。
 - NestSyetemのデバッグ機能を強化。デバッグメニューから各NestElementの情報を閲覧したり、Factoryとして登録されているAnt, NestElementの生成が行えるようになった。