### PR TITLE
初期データの整備

### DIFF
--- a/Assets/AntDiary/Definitions/DefaultEnvironment.meta
+++ b/Assets/AntDiary/Definitions/DefaultEnvironment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27a67d4b9969a5143a09bc107d4c96a1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset
+++ b/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6ef8d220b34abe449274ba9e871e459, type: 3}
+  m_Name: DefaultEnvironmentData
+  m_EditorClassIdentifier: 
+  generalPathRoads:
+  - guid: 62adc900-c2a9-4798-9654-799121b1f720
+    position: {x: -2.5, y: 3}
+    name: Default Ground
+    blockingShape:
+      serializedVersion: 2
+      x: 0
+      y: 0.5
+      width: 10
+      height: 1
+    nodeData:
+    - name: bottom
+      position: {x: 0, y: 0}
+    - name: bottom
+      position: {x: 4, y: 0}
+    - name: bottom
+      position: {x: 8, y: 0}
+    edgeData:
+    - indexA: 0
+      indexB: 1
+    - indexA: 1
+      indexB: 2

--- a/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset
+++ b/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset
@@ -23,14 +23,23 @@ MonoBehaviour:
       width: 10
       height: 1
     nodeData:
-    - name: bottom
+    - name: wild_left
       position: {x: 0, y: 0}
-    - name: bottom
+    - name: wild_middle
       position: {x: 4, y: 0}
-    - name: bottom
+    - name: _right
       position: {x: 8, y: 0}
     edgeData:
     - indexA: 0
       indexB: 1
     - indexA: 1
       indexB: 2
+  initialRoadPosition: {x: 1.5, y: 1}
+  initialRoadNodeName: top
+  initialRoadBindNodePath: 62adc900-c2a9-4798-9654-799121b1f720/wild_middle
+  sugarStackPosition: {x: -5, y: 3.5}
+  sugarStackNodeName: joint
+  sugarStackBindNodePath: 62adc900-c2a9-4798-9654-799121b1f720/wild_left
+  architectAntCount: 1
+  ergateAntCount: 2
+  unemployedAntCount: 2

--- a/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset
+++ b/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset
@@ -18,9 +18,9 @@ MonoBehaviour:
     name: Default Ground
     blockingShape:
       serializedVersion: 2
-      x: 0
+      x: 2.5
       y: 0.5
-      width: 10
+      width: 18
       height: 1
     nodeData:
     - name: wild_left
@@ -40,6 +40,7 @@ MonoBehaviour:
   sugarStackPosition: {x: -5, y: 3.5}
   sugarStackNodeName: joint
   sugarStackBindNodePath: 62adc900-c2a9-4798-9654-799121b1f720/wild_left
-  architectAntCount: 1
+  builderAntCount: 1
   ergateAntCount: 2
   unemployedAntCount: 2
+  storedFood: 0

--- a/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset.meta
+++ b/Assets/AntDiary/Definitions/DefaultEnvironment/DefaultEnvironmentData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 57cbe50017a91284c9bfa4e9258bbfb5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Definitions/GeneTree/MainGeneTree.asset
+++ b/Assets/AntDiary/Definitions/GeneTree/MainGeneTree.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 073babef4ac53484a9a39872dc31115d, type: 3}
   m_Name: MainGeneTree
   m_EditorClassIdentifier: 
-  displayName: MainTree
+  displayName: "\u30E1\u30A4\u30F3"
   genes:
   - id: speed_0
     displayName: "\u901F\u3055"

--- a/Assets/AntDiary/Prefabs/Roads/GeneralPathRoad.meta
+++ b/Assets/AntDiary/Prefabs/Roads/GeneralPathRoad.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3373a0b79f03a9041b2ce59dac98b2cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Prefabs/Roads/GeneralPathRoad/GeneralPathRoad.prefab
+++ b/Assets/AntDiary/Prefabs/Roads/GeneralPathRoad/GeneralPathRoad.prefab
@@ -1,0 +1,73 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8544605828376545205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 353115307004668287}
+  - component: {fileID: 7228188634624289815}
+  - component: {fileID: 8122701637222527651}
+  m_Layer: 0
+  m_Name: GeneralPathRoad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &353115307004668287
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8544605828376545205}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7228188634624289815
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8544605828376545205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cfae6829fd6d754f81ed7a1bdb567d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  blockingShape: {fileID: 8122701637222527651}
+--- !u!61 &8122701637222527651
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8544605828376545205}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Assets/AntDiary/Prefabs/Roads/GeneralPathRoad/GeneralPathRoad.prefab.meta
+++ b/Assets/AntDiary/Prefabs/Roads/GeneralPathRoad/GeneralPathRoad.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2863d1ea5d23fad449ed70509457b792
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Prefabs/System/MainSystem.prefab
+++ b/Assets/AntDiary/Prefabs/System/MainSystem.prefab
@@ -139,6 +139,51 @@ MonoBehaviour:
     type: 3}
   leftDirRoadPrefab: {fileID: 4481878659885024219, guid: 4b715ad7b58abc349b75e863e84dd2dd,
     type: 3}
+--- !u!1 &1819912758509366907
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 690065195781281646}
+  - component: {fileID: 2790746955359051275}
+  m_Layer: 0
+  m_Name: GeneralPathRoadFactory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &690065195781281646
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819912758509366907}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7330755635594259116}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2790746955359051275
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1819912758509366907}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 442fbdd95dec660408d1b0248f58939c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  generalPathRoadPrefab: {fileID: 8544605828376545205, guid: 2863d1ea5d23fad449ed70509457b792,
+    type: 3}
 --- !u!1 &3882576165472150745
 GameObject:
   m_ObjectHideFlags: 0
@@ -404,6 +449,7 @@ Transform:
   - {fileID: 8004003651767214842}
   - {fileID: 4334998042793489787}
   - {fileID: 615599578666001498}
+  - {fileID: 690065195781281646}
   m_Father: {fileID: 7330755635708001766}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -428,6 +474,7 @@ MonoBehaviour:
   - {fileID: 4864833772480513066}
   - {fileID: 7691373749618332889}
   - {fileID: 7329380204863080166}
+  - {fileID: 2790746955359051275}
 --- !u!1 &7330755635708001764
 GameObject:
   m_ObjectHideFlags: 0
@@ -478,6 +525,7 @@ MonoBehaviour:
   debugMenuPages:
   - {fileID: 7330755635594259107}
   - {fileID: 7330755635365534184}
+  defaultEnvironment: {fileID: 11400000, guid: 57cbe50017a91284c9bfa4e9258bbfb5, type: 2}
 --- !u!1 &7330755635714401570
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/AntDiary/Scripts/Ants/StrategyAntData.cs
+++ b/Assets/AntDiary/Scripts/Ants/StrategyAntData.cs
@@ -1,5 +1,5 @@
 namespace AntDiary.Scripts.Ants{
-	public class StrategyAntData: AntData{
+	public abstract class StrategyAntData: AntData{
 		//Strategy状態保存するならここに
 	}
 }

--- a/Assets/AntDiary/Scripts/Roads/GeneralPathRoad.meta
+++ b/Assets/AntDiary/Scripts/Roads/GeneralPathRoad.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fae3dc2753909e43a17407e50ad7092
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoad.cs
+++ b/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoad.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace AntDiary
+{
+    public class GeneralPathRoad : NestElement<GeneralPathRoadData>
+    {
+        [SerializeField] private BoxCollider2D blockingShape;
+
+        public string Id => SelfData.Name;
+
+        private NestPathRoadNode[] nodes;
+        private NestPathLocalEdge[] edges;
+
+        public override Collider2D GetBlockingShape()
+        {
+            return blockingShape;
+        }
+
+        public override bool HasPathNode => true;
+
+        public override IEnumerable<NestPathNode> GetNodes()
+        {
+            return nodes;
+        }
+
+        public override IEnumerable<NestPathLocalEdge> GetLocalEdges()
+        {
+            return edges;
+        }
+
+        protected override void OnInitialized()
+        {
+            //BlockingShapeの形成
+            if (!blockingShape) blockingShape = GetComponent<BoxCollider2D>();
+            if (!blockingShape) blockingShape = gameObject.AddComponent<BoxCollider2D>();
+
+            blockingShape.size = SelfData.BlockingShape.size;
+            blockingShape.offset = SelfData.BlockingShape.position;
+
+            //PathNodeの形成
+            nodes = SelfData.NodeData.Select(n => new NestPathRoadNode(this, n.Position, n.Name)).ToArray();
+            edges = SelfData.EdgeData.Select(e => new NestPathLocalEdge(nodes[e.IndexA], nodes[e.IndexB])).ToArray();
+        }
+    }
+}

--- a/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoad.cs.meta
+++ b/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoad.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cfae6829fd6d754f81ed7a1bdb567d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadData.cs
+++ b/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadData.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using MessagePack;
+using UnityEngine;
+
+namespace AntDiary
+{
+    [MessagePackObject(), Serializable]
+    public class GeneralPathRoadData : NestElementData
+    {
+        [SerializeField] private string name;
+        [SerializeField] private Rect blockingShape;
+        [SerializeField] private List<GeneralPathRoadNodeData> nodeData = new List<GeneralPathRoadNodeData>();
+        [SerializeField] private List<GeneralPathRoadEdgeData> edgeData = new List<GeneralPathRoadEdgeData>();
+
+        /// <summary>
+        /// シーン上にGeneralPathRoadDataが複数存在する場合に、インスタンスを一意に定めるためのID。とくに重複チェックなどの機能は持たない
+        /// </summary>
+        [Key(30)]
+        public string Name
+        {
+            get => name;
+            set => name = value;
+        }
+        
+        [Key(31)]
+        public Rect BlockingShape
+        {
+            get => blockingShape;
+            set => blockingShape = value;
+        }
+
+        [Key(32)]
+        public List<GeneralPathRoadNodeData> NodeData
+        {
+            get => nodeData;
+            set => nodeData = value;
+        }
+
+        [Key(33)]
+        public List<GeneralPathRoadEdgeData> EdgeData
+        {
+            get => edgeData;
+            set => edgeData = value;
+        }
+    }
+
+    [MessagePackObject(), Serializable]
+    public class GeneralPathRoadNodeData
+    {
+        [SerializeField] private string name;
+        [SerializeField] private Vector2 position;
+
+        [Key(0)]
+        public string Name
+        {
+            get => name;
+            set => name = value;
+        }
+
+        [Key(1)]
+        public Vector2 Position
+        {
+            get => position;
+            set => position = value;
+        }
+    }
+    
+    [MessagePackObject(), Serializable]
+    public class GeneralPathRoadEdgeData
+    {
+        [SerializeField] private int indexA;
+        [SerializeField] private int indexB;
+
+        [Key(0)]
+        public int IndexA
+        {
+            get => indexA;
+            set => indexA = value;
+        }
+
+        [Key(1)]
+        public int IndexB
+        {
+            get => indexB;
+            set => indexB = value;
+        }
+    }
+}

--- a/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadData.cs.meta
+++ b/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d621c88c113a2a441a97a6c296bd55d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadFactory.cs
+++ b/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadFactory.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AntDiary
+{
+    public class GeneralPathRoadFactory : NestElementFactory<GeneralPathRoadData>
+    {
+        [SerializeField] private GameObject generalPathRoadPrefab;
+
+        public override NestElement InstantiateNestElement(GeneralPathRoadData elementData)
+        {
+            var obj = Instantiate(generalPathRoadPrefab, elementData.Position, Quaternion.identity);
+            var ne = obj.GetComponent<GeneralPathRoad>();
+            ne.Initialize(elementData);
+            return ne;
+        }
+    }
+}

--- a/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadFactory.cs.meta
+++ b/Assets/AntDiary/Scripts/Roads/GeneralPathRoad/GeneralPathRoadFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 442fbdd95dec660408d1b0248f58939c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/Ant.cs
+++ b/Assets/AntDiary/Scripts/System/Ant.cs
@@ -126,6 +126,7 @@ namespace AntDiary
         public NestPathNode SupposeCurrentPosNode(){
             float Distance(IPathNode node) => Vector2.Distance(node.WorldPosition, transform.position);
 
+            if (NestSystem.Instance.NestPathNodes.Any()) return null;
             
             return NestSystem.Instance.NestPathNodes
                 .Aggregate((result, next) => Distance(next) < Distance(result) ? next : result);

--- a/Assets/AntDiary/Scripts/System/Data/AntData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/AntData.cs
@@ -10,6 +10,8 @@ namespace AntDiary
     [Union(2, typeof(ErgateAntData))]
     [Union(3, typeof(BuilderAntData))]
     [Union(4, typeof(QueenAntData))]
+    [Union(5, typeof(EnemyAntData))]
+    [Union(6, typeof(SoldierAntData))]
     public abstract class AntData
     {
         //方針として、AntDataのメンバ(アリの複数種に共通値)のKeyは0 ~ 99, 各継承クラスのメンバのKeyは100~にしたいな～と

--- a/Assets/AntDiary/Scripts/System/Data/NestData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestData.cs
@@ -23,5 +23,6 @@ namespace AntDiary
 
         [Key(14)]
         public AntCommonDataRegistryData CommonDataRegistry { get; set; } = new AntCommonDataRegistryData();
+        
     }
 }

--- a/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using AntDiary.Scripts.Roads;
 using MessagePack;
@@ -6,6 +7,7 @@ using UnityEngine;
 
 namespace AntDiary
 {
+    [Serializable]
     [Union(0, typeof(DebugRoomData))]
     [Union(1, typeof(DebugRoadData))]
     [Union(2, typeof(StoreRoomData))]
@@ -17,12 +19,26 @@ namespace AntDiary
     [Union(8, typeof(ChochikukoRoomData))]
     public abstract class NestElementData
     {
+        [SerializeField] private string guid = System.Guid.NewGuid().ToString();
+        [SerializeField] private Vector2 position;
+
         public NestElementData()
         {
         }
 
         //Keyは0~9を使用することにします。足りなくなったらまた考えるので@rucchoまで。
-        [Key(0)] public string Guid { get; set; } = System.Guid.NewGuid().ToString();
-        [Key(1)] public Vector2 Position { get; set; }
+        [Key(0)]
+        public string Guid
+        {
+            get => guid;
+            set => guid = value;
+        }
+
+        [Key(1)]
+        public Vector2 Position
+        {
+            get => position;
+            set => position = value;
+        }
     }
 }

--- a/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
+++ b/Assets/AntDiary/Scripts/System/Data/NestElementData.cs
@@ -17,6 +17,9 @@ namespace AntDiary
     [Union(6, typeof(TShapeRoadData))]
     [Union(7, typeof(QueenRoomData))]
     [Union(8, typeof(ChochikukoRoomData))]
+    [Union(9, typeof(GeneralPathRoadData))]
+    [Union(10, typeof(GroundData))]
+    [Union(11, typeof(MtSugarData))]
     public abstract class NestElementData
     {
         [SerializeField] private string guid = System.Guid.NewGuid().ToString();

--- a/Assets/AntDiary/Scripts/System/Data/SaveUnit.cs
+++ b/Assets/AntDiary/Scripts/System/Data/SaveUnit.cs
@@ -44,10 +44,10 @@ namespace AntDiary
         private static readonly Subject<SaveUnit> onCurrentSaveUnitChanged = new Subject<SaveUnit>();
 
         /// <summary>
-        /// 初期状態のセーブデータを生成して返す。
+        /// 空のセーブデータを生成して返す。
         /// </summary>
         /// <returns></returns>
-        public static SaveUnit GetDefaultSaveUnit()
+        public static SaveUnit GetEmptySaveUnit()
         {
             var su = new SaveUnit()
             {

--- a/Assets/AntDiary/Scripts/System/DefaultEnvironmentData.cs
+++ b/Assets/AntDiary/Scripts/System/DefaultEnvironmentData.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AntDiary
+{
+    /// <summary>
+    /// 巣の初期状態を定義するScriptableObject
+    /// </summary>
+    [CreateAssetMenu(fileName = "DefaultEnvironmentData", menuName = "AntDiary/DefaultEnvironmentData")]
+    public class DefaultEnvironmentData : ScriptableObject
+    {
+        [SerializeField] private GeneralPathRoadData[] generalPathRoads;
+        public GeneralPathRoadData[] GeneralPathRoads => generalPathRoads;
+    }
+}

--- a/Assets/AntDiary/Scripts/System/DefaultEnvironmentData.cs
+++ b/Assets/AntDiary/Scripts/System/DefaultEnvironmentData.cs
@@ -10,7 +10,37 @@ namespace AntDiary
     [CreateAssetMenu(fileName = "DefaultEnvironmentData", menuName = "AntDiary/DefaultEnvironmentData")]
     public class DefaultEnvironmentData : ScriptableObject
     {
-        [SerializeField] private GeneralPathRoadData[] generalPathRoads;
         public GeneralPathRoadData[] GeneralPathRoads => generalPathRoads;
+        [SerializeField] private GeneralPathRoadData[] generalPathRoads;
+
+        public Vector2 InitialRoadPosition => initialRoadPosition;
+        [SerializeField] private Vector2 initialRoadPosition;
+
+        public string InitialRoadNodeName => initialRoadNodeName;
+        [SerializeField]private string initialRoadNodeName;
+        
+        public string InitialRoadBindNodePath => initialRoadBindNodePath;
+        [SerializeField]private string initialRoadBindNodePath;
+
+        public Vector2 SugarStackPosition => sugarStackPosition;
+        [SerializeField] private Vector2 sugarStackPosition;
+        
+        public string SugarStackNodeName => sugarStackNodeName;
+        [SerializeField] private string sugarStackNodeName;
+        
+        public string SugarStackBindNodePath => sugarStackBindNodePath;
+        [SerializeField] private string sugarStackBindNodePath;
+
+        public int BuilderAntCount => builderAntCount;
+        [SerializeField] private int builderAntCount = 1;
+
+        public int ErgateAntCount => ergateAntCount;
+        [SerializeField] private int ergateAntCount = 2;
+        
+        public int UnemployedAntCount => unemployedAntCount;
+        [SerializeField] private int unemployedAntCount = 2;
+
+        public int StoredFood => storedFood;
+        [SerializeField] private int storedFood;
     }
 }

--- a/Assets/AntDiary/Scripts/System/DefaultEnvironmentData.cs.meta
+++ b/Assets/AntDiary/Scripts/System/DefaultEnvironmentData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6ef8d220b34abe449274ba9e871e459
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AntDiary/Scripts/System/MainSystem.cs
+++ b/Assets/AntDiary/Scripts/System/MainSystem.cs
@@ -13,6 +13,7 @@ namespace AntDiary
     {
         [SerializeField] private bool showDebugMenu = default;
         [SerializeField] private MonoBehaviour[] debugMenuPages = default;
+        [SerializeField] private DefaultEnvironmentData defaultEnvironment;
         private List<IDebugMenu> DebugMenuPages = new List<IDebugMenu>();
 
         private void Start()
@@ -20,7 +21,7 @@ namespace AntDiary
             DebugMenuPages.AddRange(debugMenuPages.OfType<IDebugMenu>());
             DebugMenuPages.Add(new SaveSystemDebugMenu());
             
-            SaveSystem.LoadDefaultSaveUnitToCurrent();
+            SaveSystem.LoadDefaultSaveUnitToCurrent(defaultEnvironment);
         }
 
         private void Update()

--- a/Assets/AntDiary/Scripts/System/NestPathElementEdge.cs
+++ b/Assets/AntDiary/Scripts/System/NestPathElementEdge.cs
@@ -62,8 +62,8 @@ namespace AntDiary
             var nodeB = elementB.GetNodes().Where(n => n.IsExposed).FirstOrDefault(n => n.Name == data.NodeNameB);
             if (nodeB == default) throw new ArgumentException("指定されたNestPathNodeが見つかりませんでした。");
             
-            if(!nodeA.IsConnectable(nodeB)) throw new ArgumentException("指定されたNestPathNodeどうしは接続を禁止しています。");
-            if(!nodeB.IsConnectable(nodeA)) throw new ArgumentException("指定されたNestPathNodeどうしは接続を禁止しています。");
+            if(!nodeA.IsConnectable(nodeB)) throw new ArgumentException($"指定されたNestPathNodeどうしは接続を禁止しています: {data.ElementGuidA}/{data.NodeNameA} -> {data.ElementGuidB}/{data.NodeNameB}");
+            if(!nodeB.IsConnectable(nodeA)) throw new ArgumentException($"指定されたNestPathNodeどうしは接続を禁止しています: {data.ElementGuidA}/{data.NodeNameA} <- {data.ElementGuidB}/{data.NodeNameB}");
 
             A = nodeA;
             B = nodeB;

--- a/Assets/AntDiary/Scripts/System/NestSystem.cs
+++ b/Assets/AntDiary/Scripts/System/NestSystem.cs
@@ -129,24 +129,25 @@ namespace AntDiary
 
             //セーブデータから巣情報をロード
 
-            //アリを生成
-            foreach (var antData in Data.Ants)
-            {
-                var ant = InstantiateAnt(antData, false);
-            }
-
             //道、部屋を生成
             foreach (var elementData in Data.Structure.NestElements)
             {
                 var element = InstantiateNestElement(elementData, false);
             }
-
+            
             //Element間の接続をロード
             foreach (var edgeData in Data.Structure.ElementEdges)
             {
                 var edge = new NestPathElementEdge(nestElements, edgeData);
                 elementEdges.Add(edge);
             }
+            
+            //アリを生成
+            foreach (var antData in Data.Ants)
+            {
+                var ant = InstantiateAnt(antData, false);
+            }
+
         }
 
 
@@ -319,6 +320,27 @@ namespace AntDiary
         public T GetAnt<T>() where T : Ant
         {
             return GetAnts<T>().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// [GUID]/[Name of node]で構成されたパスからノードを取得する。
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public NestPathNode GetNodeFromPath(string path)
+        {
+            ParseNodePath(path, out string guid, out string name);
+            return nestElements.FirstOrDefault(e => e.Data.Guid == guid)?.GetNodes().FirstOrDefault(n => n.Name == name);
+        }
+
+        public static void ParseNodePath(string path, out string guid, out string name)
+        {
+            var splitted = path.Split('/');
+            if(splitted.Length != 2) throw new ArgumentException();
+
+            guid = splitted[0];
+            name = splitted[1];
         }
 
         public IEnumerable<IPathNode> FindRoute(NestPathNode from, NestPathNode to)

--- a/Assets/AntDiary/Scripts/System/SaveSystem.cs
+++ b/Assets/AntDiary/Scripts/System/SaveSystem.cs
@@ -19,9 +19,15 @@ namespace AntDiary
             LoadSaveFile(number).SetAsCurrent();
         }
 
-        public static void LoadDefaultSaveUnitToCurrent()
+        public static void LoadDefaultSaveUnitToCurrent(DefaultEnvironmentData defaultEnvironment = null)
         {
-            SaveUnit.GetDefaultSaveUnit().SetAsCurrent();
+            var su = SaveUnit.GetDefaultSaveUnit();
+
+            //初期環境のセットアップ
+            if (defaultEnvironment != null)
+                su.s_GameContext.s_NestData.Structure.NestElements.AddRange(defaultEnvironment.GeneralPathRoads);
+
+            su.SetAsCurrent();
         }
 
         private static SaveUnit SaveSaveFile(int number, SaveUnit su)
@@ -32,7 +38,7 @@ namespace AntDiary
             System.IO.File.WriteAllBytes(fileName, raw);
             return su;
         }
-        
+
         private static SaveUnit LoadSaveFile(int number)
         {
             string fileName = GetSaveFileName(number);
@@ -45,21 +51,22 @@ namespace AntDiary
         {
             return $"{Application.persistentDataPath.TrimEnd('/', '\\')}/Save/{number}/saveunit.bin";
         }
-
     }
 
     public class SaveSystemDebugMenu : IDebugMenu
     {
         #region Debug
+
         public string pageTitle { get; } = "セーブ/ロード";
+
         public void OnGUIPage()
         {
             if (SaveUnit.Current == null)
             {
                 GUILayout.Label("セーブデータは未ロードです");
             }
-            
-            if (GUILayout.Button($"初期状態のデータをロード"))
+
+            if (GUILayout.Button($"空のデータをロード"))
             {
                 SaveSystem.LoadDefaultSaveUnitToCurrent();
             }
@@ -67,20 +74,23 @@ namespace AntDiary
             for (int i = 0; i < 4; i++)
             {
                 GUILayout.BeginHorizontal();
-                
+
                 if (GUILayout.Button($"Load from {i}"))
                 {
                     SaveSystem.LoadSaveUnitToCurrent(i);
                 }
+
                 GUI.enabled = SaveUnit.Current != null;
                 if (GUILayout.Button($"Save to {i}"))
                 {
                     SaveSystem.SaveCurrentSaveUnit(i);
                 }
+
                 GUI.enabled = true;
                 GUILayout.EndHorizontal();
             }
         }
+
         #endregion
     }
 }

--- a/Assets/AntDiary/Scripts/System/TimeSystem.cs
+++ b/Assets/AntDiary/Scripts/System/TimeSystem.cs
@@ -163,6 +163,7 @@ namespace AntDiary
 
         private void LoadTime()
         {
+            Debug.Log("LoadTime");
             if (SaveUnit.Current != null)
             {
                 timeOffset = GameContext.Current.s_CurrentTime;


### PR DESCRIPTION
## 初期データ
 - 初期データ定義アセットDefaultEnvironmentData (ScriptableObject)を追加
   - 初期配置NestElement (餌場、地面ノード、初期道路など)の設定がアセットから可能
   - 初期配置アリの数を指定
   - Assets/AntDiary/Definitions/DefaultEnvironmentに作成済みです。既にMainSystemにセットされています
 - 初期地面ノードの追加に伴ってGeneralPathRoad (NestElement) を追加。Dataにノードの構造情報を持ち、柔軟に経路を設定できる

## セーブ/ロード
 - 軽微な修正
   - ロードの処理順を変更（NestElement -> Antの順に生成）
   - MessagePackObject, Unionの付け忘れを修正